### PR TITLE
Packages new guava in the module as it is later than spring boot

### DIFF
--- a/autoconfigure/storage-stackdriver/pom.xml
+++ b/autoconfigure/storage-stackdriver/pom.xml
@@ -100,7 +100,7 @@
             io.zipkin.java,io.zipkin.zipkin2,org.springframework.boot,commons-codec,com.fasterxml.jackson.core,com.fasterxml.jackson.dataformat,org.apache.httpcomponents,commons-logging,joda-time
           </excludeGroupIds>
           <!-- already packaged in zipkin-server -->
-          <excludeArtifactIds>guava,gson,okio</excludeArtifactIds>
+          <excludeArtifactIds>gson,okio</excludeArtifactIds>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
avoids this crash
```
Caused by: java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;CLjava/lang/Object;)V
	at io.grpc.Metadata$Key.validateName(Metadata.java:628) ~[grpc-core-1.11.0.jar!/:1.11.0]
	at io.grpc.Metadata$Key.<init>(Metadata.java:636) ~[grpc-core-1.11.0.jar!/:1.11.0]
	at io.grpc.Metadata$Key.<init>(Metadata.java:566) ~[grpc-core-1.11.0.jar!/:1.11.0]
	at io.grpc.Metadata$AsciiKey.<init>(Metadata.java:740) ~[grpc-core-1.11.0.jar!/:1.11.0]
	at io.grpc.Metadata$AsciiKey.<init>(Metadata.java:735) ~[grpc-core-1.11.0.jar!/:1.11.0]
	at io.grpc.Metadata$Key.of(Metadata.java:592) ~[grpc-core-1.11.0.jar!/:1.11.0]
```