### PR TITLE
Logs translation when SpanTranslator is at FINE/DEBUG level

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,46 @@ yourself by downloading a couple jars.
 
 [Here's an example](autoconfigure/storage-stackdriver#quick-start) of
 integrating Stackdriver storage.
+
+## Troubleshooting translation issues
+
+When using a component that sends data to Stackdriver, if you see nothing in the console,
+try enabling DEBUG logging on the translation component. If using Spring Boot (ex normal
+app or zipkin server integration), add the following system property:
+
+```
+-Dlogging.level.zipkin2.translation.stackdriver=DEBUG
+```
+
+Note: If using our docker image or anything that uses JAVA_OPTS, you can add this there.
+
+With this in place, you'll see the input and output of translation like below. Keep a copy
+of this when contacting us on [gitter](https://gitter.im/openzipkin/zipkin) for support.
+
+```
+2018-04-09 13:58:44.112 DEBUG [/] 11325 --- [   XNIO-2 I/O-3] z.t.stackdriver.SpanTranslator           : >> translating zipkin span: {"traceId":"d42316227862f939","parentId":"d42316227862f939","id":"dfbb21f9cf4c52b3","kind":"CLIENT","name":"get","timestamp":1523253523054380,"duration":4536,"localEndpoint":{"serviceName":"frontend","ipv4":"192.168.1.113"},"tags":{"http.method":"GET","http.path":"/api"}}
+2018-04-09 13:58:44.113 DEBUG [/] 11325 --- [   XNIO-2 I/O-3] z.t.stackdriver.SpanTranslator           : << translated to stackdriver span: span_id: 16199746076534411288
+kind: RPC_CLIENT
+name: "get"
+start_time {
+  seconds: 1523253523
+  nanos: 54380000
+}
+end_time {
+  seconds: 1523253523
+  nanos: 58916000
+}
+parent_span_id: 15286085897530046777
+labels {
+  key: "/http/method"
+  value: "GET"
+}
+labels {
+  key: "zipkin.io/http.path"
+  value: "/api"
+}
+labels {
+  key: "/component"
+  value: "frontend"
+}
+```

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
@@ -18,6 +18,8 @@ import com.google.devtools.cloudtrace.v1.TraceSpan.SpanKind;
 import com.google.protobuf.Timestamp;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import zipkin2.Span;
 
 /**
@@ -29,6 +31,7 @@ import zipkin2.Span;
  * server-side span. Other parent-child relationships will be preserved.
  */
 public final class SpanTranslator {
+  private static final Logger LOG = Logger.getLogger(SpanTranslator.class.getName());
 
   static final LabelExtractor labelExtractor;
 
@@ -58,6 +61,8 @@ public final class SpanTranslator {
    * @return A Stackdriver Trace Span.
    */
   public static TraceSpan.Builder translate(TraceSpan.Builder spanBuilder, Span zipkinSpan) {
+    boolean logTranslation = LOG.isLoggable(Level.FINE);
+    if (logTranslation) LOG.fine(">> translating zipkin span: " + zipkinSpan);
     spanBuilder.setName(zipkinSpan.name() != null ? zipkinSpan.name() : "");
     SpanKind kind = getSpanKind(zipkinSpan.kind());
     spanBuilder.setKind(kind);
@@ -72,6 +77,7 @@ public final class SpanTranslator {
       }
     }
     spanBuilder.putAllLabels(labelExtractor.extract(zipkinSpan));
+    if (logTranslation) LOG.fine("<< translated to stackdriver span: " + spanBuilder);
     return spanBuilder;
   }
 


### PR DESCRIPTION
We've had a number of support issues around translation. This adds debug
logging which can help determine the cause of failures.

```
2018-04-09 13:51:19.279 DEBUG [/] 7295 --- [   XNIO-2 I/O-2] z.t.stackdriver.SpanTranslator           : >> translating zipkin span: {"traceId":"e7d33ab8fe95b3cb","id":"e7d33ab8fe95b3cb","kind":"SERVER","name":"get /","timestamp":1523253078006004,"duration":158196,"localEndpoint":{"serviceName":"frontend","ipv4":"192.168.1.113"},"remoteEndpoint":{"ipv6":"::1","port":60162},"tags":{"http.method":"GET","http.path":"/","mvc.controller.class":"Frontend","mvc.controller.method":"callBackend"}}
2018-04-09 13:51:19.281 DEBUG [/] 7295 --- [   XNIO-2 I/O-2] z.t.stackdriver.SpanTranslator           : << translated to stackdriver span: span_id: 16704760009066918859
kind: RPC_SERVER
name: "get /"
start_time {
  seconds: 1523253078
  nanos: 6004000
}
end_time {
  seconds: 1523253078
  nanos: 164200000
}
labels {
  key: "/http/method"
  value: "GET"
}
labels {
  key: "zipkin.io/http.path"
  value: "/"
}
labels {
  key: "zipkin.io/mvc.controller.class"
  value: "Frontend"
}
labels {
  key: "zipkin.io/mvc.controller.method"
  value: "callBackend"
}
labels {
  key: "zipkin.io/endpoint.ipv4"
  value: "192.168.1.113"
}
labels {
  key: "/component"
  value: "frontend"
}
labels {
  key: "/agent"
  value: "zipkin-java"
}
```