### PR TITLE
Adds span kinds CONSUMER and PRODUCER

### DIFF
--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
@@ -140,6 +140,8 @@ public final class SpanTranslator {
   }
 
   private static SpanKind getSpanKind(/* Nullable */ Span.Kind zipkinKind) {
+    // Stackdriver Trace still does not have any match for CONSUMER or PRODUCER, and sending it as
+    // UNRECOGNIZED triggers an error.
     if (zipkinKind == null
             || zipkinKind == Span.Kind.CONSUMER
             || zipkinKind == Span.Kind.PRODUCER) {

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
@@ -140,7 +140,11 @@ public final class SpanTranslator {
   }
 
   private static SpanKind getSpanKind(/* Nullable */ Span.Kind zipkinKind) {
-    if (zipkinKind == null) return SpanKind.SPAN_KIND_UNSPECIFIED;
+    if (zipkinKind == null
+            || zipkinKind == Span.Kind.CONSUMER
+            || zipkinKind == Span.Kind.PRODUCER) {
+      return SpanKind.SPAN_KIND_UNSPECIFIED;
+    }
     if (zipkinKind == Span.Kind.CLIENT) {
       return SpanKind.RPC_CLIENT;
     }

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
@@ -69,4 +69,15 @@ public class SpanTranslatorTest {
         .isEqualTo(TraceSpan.getDefaultInstance().getName())
         .isEmpty();
   }
+
+  @Test public void translate_consumerProducerSpan() {
+    assertThat(SpanTranslator.translate(TraceSpan.newBuilder(),
+            Span.newBuilder().traceId("2").id("3").kind(Span.Kind.CONSUMER).build())
+            .build().getKind())
+            .isEqualTo(TraceSpan.SpanKind.SPAN_KIND_UNSPECIFIED);
+    assertThat(SpanTranslator.translate(TraceSpan.newBuilder(),
+            Span.newBuilder().traceId("2").id("3").kind(Span.Kind.PRODUCER).build())
+            .build().getKind())
+            .isEqualTo(TraceSpan.SpanKind.SPAN_KIND_UNSPECIFIED);
+  }
 }


### PR DESCRIPTION
Associates them with SPAN_KIND_UNSPECIFIED on the Stackdriver side,
since, according to CONSUMER and PRODUCER's Javadoc, they don't have
trace IDs, therefore shouldn't be either SpanKind.RPC_CLIENT or
SpanKind.RPC_SERVER.