### PR TITLE
Removes the ID rewriting code in favor of application configuration

### DIFF
--- a/sender-stackdriver/README.md
+++ b/sender-stackdriver/README.md
@@ -25,6 +25,9 @@ sender = StackdriverSender.newBuilder()
 reporter = AsyncReporter.newBuilder(sender).build(StackdriverEncoder.V1);
 ```
 
+Note: Use 128-bit trace IDs and do not re-use span IDs across client and server.
+* Ex. in Brave `Tracing.Builder.supportsJoin(false).traceId128Bit(true)`
+
 Note: There are a few library dependencies implied
 * io.grpc:grpc-auth < for authentication in general
 * com.google.auth:google-auth-library-oauth2-http < for GCP oauth

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/TraceTranslator.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/TraceTranslator.java
@@ -22,7 +22,7 @@ import java.util.Comparator;
 import java.util.List;
 import zipkin2.Span;
 
-/** Convenience utility for those not using  */
+/** Convenience utility for those not using io.zipkin.gcp:zipkin-sender-stackdriver */
 public final class TraceTranslator {
 
   /**

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
@@ -45,8 +45,7 @@ public class SpanTranslatorTest {
 
     assertThat(translated).isEqualTo(
         TraceSpan.newBuilder()
-            // client spans have their id rewritten with a consistent function
-            .setSpanId(Long.parseUnsignedLong(zipkinSpan.id(), 16) ^ 0x3f6a2ec3c810c2abL)
+            .setSpanId(Long.parseUnsignedLong(zipkinSpan.id(), 16))
             .setParentSpanId(Long.parseUnsignedLong(zipkinSpan.parentId(), 16))
             .setKind(TraceSpan.SpanKind.RPC_CLIENT)
             .setName("get")


### PR DESCRIPTION
Applications can be configured to not share IDs across client and
server. This is more reliable than rewriting IDs and also doesn't
conflict with log statements which have the correct IDs in them.

Fixes #67