### PR TITLE
Implements GCP propagation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <!-- must match https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
     <grpc.version>1.11.0</grpc.version>
     <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
+    <brave.version>5.0.0</brave.version>
   </properties>
 
   <name>Zipkin Google Cloud Platform(Parent)</name>
@@ -156,6 +157,12 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>1.3</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave</artifactId>
+        <version>5.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <module>translation-stackdriver</module>
     <module>sender-stackdriver</module>
     <module>storage-stackdriver</module>
+    <module>propagation-stackdriver</module>
   </modules>
 
   <properties>

--- a/propagation-stackdriver/pom.xml
+++ b/propagation-stackdriver/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2018 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>zipkin-gcp-parent</artifactId>
+        <groupId>io.zipkin.gcp</groupId>
+        <version>0.4.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zipkin-propagation-stackdriver</artifactId>
+
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/propagation-stackdriver/pom.xml
+++ b/propagation-stackdriver/pom.xml
@@ -20,11 +20,11 @@
     <parent>
         <artifactId>zipkin-gcp-parent</artifactId>
         <groupId>io.zipkin.gcp</groupId>
-        <version>0.4.2-SNAPSHOT</version>
+        <version>0.5.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>zipkin-propagation-stackdriver</artifactId>
+    <artifactId>brave-propagation-stackdriver</artifactId>
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave</artifactId>
-            <version>5.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
@@ -37,7 +37,7 @@ public class CompositeExtractor<C> implements TraceContext.Extractor<C> {
     return context;
   }
 
-  public static class FACTORY {
+  public static class Factory {
 
     public static <C> CompositeExtractor<C> newCompositeExtractor(
         TraceContext.Extractor<C>... extractors) {

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
@@ -16,6 +16,10 @@ package zipkin2.propagation.stackdriver;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 
+/**
+ * Composite extractor that tries several extractors, in order, to retrieve the tracing context
+ * from a source.
+ */
 public class CompositeExtractor<C> implements TraceContext.Extractor<C> {
 
   private final TraceContext.Extractor<C>[] extractors;

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
@@ -18,22 +18,39 @@ import brave.propagation.TraceContextOrSamplingFlags;
 
 public class CompositeExtractor<C> implements TraceContext.Extractor<C> {
 
-	private TraceContext.Extractor<C>[] extractors;
+  private final TraceContext.Extractor<C>[] extractors;
 
-	public CompositeExtractor(TraceContext.Extractor<C>... extractors) {
-		this.extractors = extractors;
-	}
+  private CompositeExtractor(TraceContext.Extractor<C>... extractors) {
+    this.extractors = extractors;
+  }
 
-	@Override
-	public TraceContextOrSamplingFlags extract(C carrier) {
-		TraceContextOrSamplingFlags context = TraceContextOrSamplingFlags.EMPTY;
+  @Override
+  public TraceContextOrSamplingFlags extract(C carrier) {
+    TraceContextOrSamplingFlags context = TraceContextOrSamplingFlags.EMPTY;
 
-		int currentExtractor = 0;
-		while (context == TraceContextOrSamplingFlags.EMPTY
-				&& currentExtractor < extractors.length) {
-			context = extractors[currentExtractor++].extract(carrier);
-		}
+    int currentExtractor = 0;
+    while (context == TraceContextOrSamplingFlags.EMPTY
+        && currentExtractor < extractors.length) {
+      context = extractors[currentExtractor++].extract(carrier);
+    }
 
-		return context;
-	}
+    return context;
+  }
+
+  public static class FACTORY {
+
+    public static <C> CompositeExtractor<C> newCompositeExtractor(
+        TraceContext.Extractor<C>... extractors) {
+      if (extractors == null) {
+        throw new NullPointerException("The extractors array can't be null.");
+      }
+      if (extractors.length == 0) {
+        throw new IllegalArgumentException("There must be one or more extractors.");
+      }
+
+      TraceContext.Extractor<C>[] extractorsCopy = new TraceContext.Extractor[extractors.length];
+      System.arraycopy(extractors, 0, extractorsCopy, 0, extractors.length);
+      return new CompositeExtractor<>(extractorsCopy);
+    }
+  }
 }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/CompositeExtractor.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.propagation.stackdriver;
+
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+
+public class CompositeExtractor<C> implements TraceContext.Extractor<C> {
+
+	private TraceContext.Extractor<C>[] extractors;
+
+	public CompositeExtractor(TraceContext.Extractor<C>... extractors) {
+		this.extractors = extractors;
+	}
+
+	@Override
+	public TraceContextOrSamplingFlags extract(C carrier) {
+		TraceContextOrSamplingFlags context = TraceContextOrSamplingFlags.EMPTY;
+
+		int currentExtractor = 0;
+		while (context == TraceContextOrSamplingFlags.EMPTY
+				&& currentExtractor < extractors.length) {
+			context = extractors[currentExtractor++].extract(carrier);
+		}
+
+		return context;
+	}
+}

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -64,8 +64,9 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
 
   /**
    * Return the "x-cloud-trace-context" key.
-   * The value for that key is formatted in the following way:
-   * "x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
+   * The value for that key is formatted in the
+   * "x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE" or
+   * ""x-cloud-trace-context: TRACE_ID/SPAN_ID" formats.
    */
   public K getTraceIdKey() {
     return traceIdKey;

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.propagation.stackdriver;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
+
+public final class StackdriverTracePropagation<K> implements Propagation<K> {
+
+	public static final Propagation.Factory FACTORY = new Propagation.Factory() {
+		@Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+			return new StackdriverTracePropagation<>(keyFactory);
+		}
+
+		@Override public boolean supportsJoin() {
+			return true;
+		}
+
+		@Override public String toString() {
+			return "StackdriverTracePropagationFactory";
+		}
+	};
+
+	/**
+	 * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+	 */
+	private static final String TRACE_ID_NAME = "x-cloud-trace-context";
+
+	private static final Logger LOG = Logger.getLogger(StackdriverTracePropagation.class.getName());
+
+	private Propagation<K> b3Propagation;
+	private final K traceIdKey;
+	private List<K> fields;
+
+	StackdriverTracePropagation(KeyFactory<K> keyFactory) {
+		this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
+		this.fields = Collections.unmodifiableList(Collections.singletonList(traceIdKey));
+		this.b3Propagation = B3Propagation.FACTORY.create(keyFactory);
+	}
+
+	@Override public List<K> keys() {
+		return fields;
+	}
+
+	@Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+		return b3Propagation.injector(setter);
+	}
+
+	@Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+		if (getter == null) throw new NullPointerException("getter == null");
+		return new CompositeExtractor<>(
+				new XCloudTraceContextExtractor<>(this, getter),
+				b3Propagation.extractor(getter));
+	}
+
+	static final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<C> {
+		final StackdriverTracePropagation<K> propagation;
+		final Getter<C, K> getter;
+
+		XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
+									Getter<C, K> getter) {
+			this.propagation = propagation;
+			this.getter = getter;
+		}
+
+		@Override public TraceContextOrSamplingFlags extract(C carrier) {
+			if (carrier == null) throw new NullPointerException("carrier == null");
+
+			TraceContextOrSamplingFlags result = TraceContextOrSamplingFlags.EMPTY;
+
+			String xCloudTraceContext = getter.get(carrier, propagation.traceIdKey);
+
+			if (xCloudTraceContext != null) {
+				String[] tokens = xCloudTraceContext.split("/");
+
+				// Try to parse the trace IDs into the context
+				TraceContext.Builder context = TraceContext.newBuilder();
+
+				if (tokens.length >= 2) {
+					long[] traceId = convertHexTraceIdToLong(tokens[0]);
+					int semicolonPos = tokens[1].indexOf(";");
+					String spanId = semicolonPos == -1
+							? tokens[1]
+							: tokens[1].substring(0, semicolonPos);
+					if (traceId != null) {
+						result = TraceContextOrSamplingFlags.create(
+								context.traceIdHigh(traceId[0])
+										.traceId(traceId[1])
+										.spanId(Long.parseLong(spanId)).build());
+					}
+				}
+			}
+
+			return result;
+		}
+
+		private long[] convertHexTraceIdToLong(String hexTraceId) {
+			long[] result = new long[2];
+			int length = hexTraceId.length();
+
+			if (length != 32) return null;
+
+			// left-most characters, if any, are the high bits
+			int traceIdIndex = Math.max(0, length - 16);
+
+			result[0] = lenientLowerHexToUnsignedLong(hexTraceId, 0, traceIdIndex);
+			if (result[0] == 0) {
+				if (LOG.isLoggable(Level.FINE)) {
+					LOG.fine(hexTraceId + " is not a lower hex string.");
+				}
+				return null;
+			}
+
+			// right-most up to 16 characters are the low bits
+			result[1] = lenientLowerHexToUnsignedLong(hexTraceId, traceIdIndex, length);
+			if (result[1] == 0) {
+				if (LOG.isLoggable(Level.FINE)) {
+					LOG.fine(hexTraceId + " is not a lower hex string.");
+				}
+				return null;
+			}
+			return result;
+		}
+	}
+}
+

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -19,6 +19,14 @@ import brave.propagation.TraceContext;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Stackdriver Trace propagation.
+ *
+ * <p>Tries to extract a trace ID and span ID using the {@code x-cloud-trace-context} key.
+ * If not present, tries the B3 key set, such as {@code X-B3-TraceId}, {@code X-B3-SpanId}, etc.
+ *
+ * <p>Uses {@link B3Propagation} injection, to inject the tracing context using B3 headers.
+ */
 public final class StackdriverTracePropagation<K> implements Propagation<K> {
 
   public static final Propagation.Factory FACTORY = new Propagation.Factory() {
@@ -54,6 +62,11 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
     this.b3Propagation = B3Propagation.FACTORY.create(keyFactory);
   }
 
+  /**
+   * Return the "x-cloud-trace-context" key.
+   * The value for that key is formatted in the following way:
+   * "x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
+   */
   public K getTraceIdKey() {
     return traceIdKey;
   }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -68,7 +68,7 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
 
   @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
     if (getter == null) throw new NullPointerException("getter == null");
-    return CompositeExtractor.FACTORY.newCompositeExtractor(
+    return CompositeExtractor.Factory.newCompositeExtractor(
         new XCloudTraceContextExtractor<>(this, getter),
         b3Propagation.extractor(getter));
   }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -16,131 +16,61 @@ package zipkin2.propagation.stackdriver;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
-import brave.propagation.TraceContextOrSamplingFlags;
-
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 
 public final class StackdriverTracePropagation<K> implements Propagation<K> {
 
-	public static final Propagation.Factory FACTORY = new Propagation.Factory() {
-		@Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-			return new StackdriverTracePropagation<>(keyFactory);
-		}
+  public static final Propagation.Factory FACTORY = new Propagation.Factory() {
+    @Override public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
+      return new StackdriverTracePropagation<>(keyFactory);
+    }
 
-		@Override public boolean supportsJoin() {
-			return true;
-		}
+    @Override public boolean supportsJoin() {
+      return false;
+    }
 
-		@Override public String toString() {
-			return "StackdriverTracePropagationFactory";
-		}
-	};
+    @Override public boolean requires128BitTraceId() {
+      return true;
+    }
 
-	/**
-	 * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
-	 */
-	private static final String TRACE_ID_NAME = "x-cloud-trace-context";
+    @Override public String toString() {
+      return "StackdriverTracePropagationFactory";
+    }
+  };
 
-	private static final Logger LOG = Logger.getLogger(StackdriverTracePropagation.class.getName());
+  /**
+   * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+   */
+  private static final String TRACE_ID_NAME = "x-cloud-trace-context";
 
-	private Propagation<K> b3Propagation;
-	private final K traceIdKey;
-	private List<K> fields;
+  private Propagation<K> b3Propagation;
+  private final K traceIdKey;
+  private List<K> fields;
 
-	StackdriverTracePropagation(KeyFactory<K> keyFactory) {
-		this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
-		this.fields = Collections.unmodifiableList(Collections.singletonList(traceIdKey));
-		this.b3Propagation = B3Propagation.FACTORY.create(keyFactory);
-	}
+  StackdriverTracePropagation(KeyFactory<K> keyFactory) {
+    this.traceIdKey = keyFactory.create(TRACE_ID_NAME);
+    this.fields = Collections.singletonList(traceIdKey);
+    this.b3Propagation = B3Propagation.FACTORY.create(keyFactory);
+  }
 
-	@Override public List<K> keys() {
-		return fields;
-	}
+  public K getTraceIdKey() {
+    return traceIdKey;
+  }
 
-	@Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
-		return b3Propagation.injector(setter);
-	}
+  @Override public List<K> keys() {
+    return fields;
+  }
 
-	@Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
-		if (getter == null) throw new NullPointerException("getter == null");
-		return new CompositeExtractor<>(
-				new XCloudTraceContextExtractor<>(this, getter),
-				b3Propagation.extractor(getter));
-	}
+  @Override public <C> TraceContext.Injector<C> injector(Setter<C, K> setter) {
+    return b3Propagation.injector(setter);
+  }
 
-	static final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<C> {
-		final StackdriverTracePropagation<K> propagation;
-		final Getter<C, K> getter;
-
-		XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
-									Getter<C, K> getter) {
-			this.propagation = propagation;
-			this.getter = getter;
-		}
-
-		@Override public TraceContextOrSamplingFlags extract(C carrier) {
-			if (carrier == null) throw new NullPointerException("carrier == null");
-
-			TraceContextOrSamplingFlags result = TraceContextOrSamplingFlags.EMPTY;
-
-			String xCloudTraceContext = getter.get(carrier, propagation.traceIdKey);
-
-			if (xCloudTraceContext != null) {
-				String[] tokens = xCloudTraceContext.split("/");
-
-				// Try to parse the trace IDs into the context
-				TraceContext.Builder context = TraceContext.newBuilder();
-
-				if (tokens.length >= 2) {
-					long[] traceId = convertHexTraceIdToLong(tokens[0]);
-					int semicolonPos = tokens[1].indexOf(";");
-					String spanId = semicolonPos == -1
-							? tokens[1]
-							: tokens[1].substring(0, semicolonPos);
-					if (traceId != null) {
-						result = TraceContextOrSamplingFlags.create(
-								context.traceIdHigh(traceId[0])
-										.traceId(traceId[1])
-										.spanId(Long.parseLong(spanId)).build());
-					}
-				}
-			}
-
-			return result;
-		}
-
-		private long[] convertHexTraceIdToLong(String hexTraceId) {
-			long[] result = new long[2];
-			int length = hexTraceId.length();
-
-			if (length != 32) return null;
-
-			// left-most characters, if any, are the high bits
-			int traceIdIndex = Math.max(0, length - 16);
-
-			result[0] = lenientLowerHexToUnsignedLong(hexTraceId, 0, traceIdIndex);
-			if (result[0] == 0) {
-				if (LOG.isLoggable(Level.FINE)) {
-					LOG.fine(hexTraceId + " is not a lower hex string.");
-				}
-				return null;
-			}
-
-			// right-most up to 16 characters are the low bits
-			result[1] = lenientLowerHexToUnsignedLong(hexTraceId, traceIdIndex, length);
-			if (result[1] == 0) {
-				if (LOG.isLoggable(Level.FINE)) {
-					LOG.fine(hexTraceId + " is not a lower hex string.");
-				}
-				return null;
-			}
-			return result;
-		}
-	}
+  @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
+    if (getter == null) throw new NullPointerException("getter == null");
+    return CompositeExtractor.FACTORY.newCompositeExtractor(
+        new XCloudTraceContextExtractor<>(this, getter),
+        b3Propagation.extractor(getter));
+  }
 }
 

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -40,7 +40,7 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
   };
 
   /**
-   * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+   * 128 trace ID lower-hex encoded into 32 characters (required)
    */
   private static final String TRACE_ID_NAME = "x-cloud-trace-context";
 

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin2.propagation.stackdriver;
+
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
+
+public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<C> {
+
+  private static final Logger LOG = Logger.getLogger(XCloudTraceContextExtractor.class.getName());
+
+  private final StackdriverTracePropagation<K> propagation;
+  private final Propagation.Getter<C, K> getter;
+
+  XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
+      Propagation.Getter<C, K> getter) {
+    this.propagation = propagation;
+    this.getter = getter;
+  }
+
+  @Override public TraceContextOrSamplingFlags extract(C carrier) {
+    if (carrier == null) throw new NullPointerException("carrier == null");
+
+    TraceContextOrSamplingFlags result = TraceContextOrSamplingFlags.EMPTY;
+
+    String xCloudTraceContext = getter.get(carrier, propagation.getTraceIdKey());
+
+    if (xCloudTraceContext != null) {
+      String[] tokens = xCloudTraceContext.split("/");
+
+      // Try to parse the trace IDs into the context
+      TraceContext.Builder context = TraceContext.newBuilder();
+
+      if (tokens.length >= 2) {
+        long[] traceId = convertHexTraceIdToLong(tokens[0]);
+        int semicolonPos = tokens[1].indexOf(";");
+        String spanId = semicolonPos == -1
+            ? tokens[1]
+            : tokens[1].substring(0, semicolonPos);
+        if (traceId != null) {
+          result = TraceContextOrSamplingFlags.create(
+              context.traceIdHigh(traceId[0])
+                  .traceId(traceId[1])
+                  .spanId(Long.parseLong(spanId)).build());
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private long[] convertHexTraceIdToLong(String hexTraceId) {
+    long[] result = new long[2];
+    int length = hexTraceId.length();
+
+    if (length != 32) return null;
+
+    // left-most characters, if any, are the high bits
+    int traceIdIndex = Math.max(0, length - 16);
+
+    result[0] = lenientLowerHexToUnsignedLong(hexTraceId, 0, traceIdIndex);
+    if (result[0] == 0) {
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.fine(hexTraceId + " is not a lower hex string.");
+      }
+      return null;
+    }
+
+    // right-most up to 16 characters are the low bits
+    result[1] = lenientLowerHexToUnsignedLong(hexTraceId, traceIdIndex, length);
+    if (result[1] == 0) {
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.fine(hexTraceId + " is not a lower hex string.");
+      }
+      return null;
+    }
+    return result;
+  }
+}

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -29,7 +29,7 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
   private final StackdriverTracePropagation<K> propagation;
   private final Propagation.Getter<C, K> getter;
 
-  XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
+  public XCloudTraceContextExtractor(StackdriverTracePropagation<K> propagation,
       Propagation.Getter<C, K> getter) {
     this.propagation = propagation;
     this.getter = getter;

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -35,6 +35,12 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
     this.getter = getter;
   }
 
+  /**
+   * Creates a tracing context if the extracted string follows the
+   * "x-cloud-trace-context: TRACE_ID/SPAN_ID" format; or the
+   * "x-cloud-trace-context: TRACE_ID/SPAN_ID;0=TRACE_TRUE" format and {@code TRACE_TRUE}'s value is
+   * {@code 1}.
+   */
   @Override public TraceContextOrSamplingFlags extract(C carrier) {
     if (carrier == null) throw new NullPointerException("carrier == null");
 
@@ -54,7 +60,10 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
         String spanId = semicolonPos == -1
             ? tokens[1]
             : tokens[1].substring(0, semicolonPos);
-        if (traceId != null) {
+        boolean traceTrue = semicolonPos == -1
+            || tokens[1].length() == semicolonPos + 4 && tokens[1].charAt(semicolonPos + 3) == '1';
+
+        if (traceId != null && traceTrue) {
           result = TraceContextOrSamplingFlags.create(
               context.traceIdHigh(traceId[0])
                   .traceId(traceId[1])

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.propagation.stackdriver;
+
+import brave.propagation.Propagation;
+import brave.propagation.TraceContextOrSamplingFlags;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XCloudTraceContextExtractorTest {
+
+  @Test
+  public void testExtractXCloudTraceContext() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=1";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation) StackdriverTracePropagation.FACTORY.create(
+                Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+  }
+
+  @Test
+  public void testExtractXCloudTraceContext_noTraceTrue() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation) StackdriverTracePropagation.FACTORY.create(
+                Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+  }
+
+  @Test
+  public void testInvalidXCloudTraceContext() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation) StackdriverTracePropagation.FACTORY.create(
+                Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+  }
+}

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class XCloudTraceContextExtractorTest {
 
   @Test
-  public void testExtractXCloudTraceContext() {
+  public void testExtractXCloudTraceContext_traceTrue() {
     String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=1";
     XCloudTraceContextExtractor extractor =
         new XCloudTraceContextExtractor<>(
@@ -34,6 +34,32 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+  }
+
+  @Test
+  public void testExtractXCloudTraceContext_traceFalse() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=0";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation) StackdriverTracePropagation.FACTORY.create(
+                Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+  }
+
+  @Test
+  public void testExtractXCloudTraceContext_invalidTraceTrue() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation) StackdriverTracePropagation.FACTORY.create(
+                Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
   }
 
   @Test
@@ -52,7 +78,7 @@ public class XCloudTraceContextExtractorTest {
   }
 
   @Test
-  public void testInvalidXCloudTraceContext() {
+  public void testExtractXCloudTraceContext_noSpanId() {
     String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317";
     XCloudTraceContextExtractor extractor =
         new XCloudTraceContextExtractor<>(


### PR DESCRIPTION
This propagation re-uses B3Propagation's injector, while adding a new
CompositeExtractor concept that aims at extracting multiple trace IDs,
in order.

In this case, we're interested in extracting the trace ID from the
'x-cloud-trace-context' header, followed by 'X-B3-TraceId'.

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/703