### PR TITLE
Fixes issue where span ID is bigger than long in GAE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.6</main.java.version>
-    <main.signature.artifact>java16</main.signature.artifact>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
 
     <main.basedir>${project.basedir}</main.basedir>
 

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -66,9 +66,7 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
   }
 
   /**
-   * Return the "x-cloud-trace-context" key. The value for that key is formatted in the
-   * "x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE" or ""x-cloud-trace-context:
-   * TRACE_ID/SPAN_ID" formats.
+   * Return the "x-cloud-trace-context" key.
    */
   public K getTraceIdKey() {
     return traceIdKey;

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -54,11 +54,15 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
       // Try to parse the trace IDs into the context
       TraceContext.Builder context = TraceContext.newBuilder();
       long[] traceId = convertHexTraceIdToLong(tokens[0]);
+      // traceId is null if invalid
       if (traceId != null) {
         boolean traceTrue = true;
 
+        String spanId = "1";
+        // A span ID exists. A TRACE_TRUE flag also possibly exists.
         if (tokens.length >= 2) {
           int semicolonPos = tokens[1].indexOf(";");
+          spanId = semicolonPos == -1 ? tokens[1] : tokens[1].substring(0, semicolonPos);
           traceTrue = semicolonPos == -1
                   || tokens[1].length() == semicolonPos + 4
                   && tokens[1].charAt(semicolonPos + 3) == '1';
@@ -66,7 +70,10 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
 
         if (traceTrue) {
           result = TraceContextOrSamplingFlags.create(
-                  context.traceIdHigh(traceId[0]).traceId(traceId[1]).spanId(1L).build());
+                  context.traceIdHigh(traceId[0])
+                          .traceId(traceId[1])
+                          .spanId(Long.parseUnsignedLong(spanId))
+                          .build());
         }
       }
     }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -72,7 +72,7 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
           result = TraceContextOrSamplingFlags.create(
                   context.traceIdHigh(traceId[0])
                           .traceId(traceId[1])
-                          .spanId(Long.parseUnsignedLong(spanId))
+                          .spanId(parseUnsignedLong(spanId))
                           .build());
         }
       }
@@ -107,5 +107,58 @@ public final class XCloudTraceContextExtractor<C, K> implements TraceContext.Ext
       return null;
     }
     return result;
+  }
+
+  /** Strictly parses unsigned numbers without a java 8 dependency. */
+  static long parseUnsignedLong(String input) throws NumberFormatException {
+    if (input == null) throw new NumberFormatException("input == null");
+    int len = input.length();
+    if (len == 0) throw new NumberFormatException("empty input");
+    if (len > 20) throw new NumberFormatException("too long for uint64: " + input);
+
+    // Bear in mind the following:
+    // * maximum int64  is  9223372036854775807. Note it is 19 characters
+    // * maximum uint64 is 18446744073709551615. Note it is 20 characters
+
+    // It is safe to use defaults to parse <= 18 characters.
+    if (len <= 18) return Long.parseLong(input);
+
+    // we now know it is 19 or 20 characters: safely parse the left 18 characters
+    long left = Long.parseLong(input.substring(0, 18));
+
+    int digit19 = digitAt(input, 18);
+    int rightDigits = 20 - len;
+    if (rightDigits == 1) {
+      return left * 10 + digit19; // even 19 9's fit safely in a uint64
+    }
+
+    int digit20 = digitAt(input, 19);
+    int right = digit19 * 10 + digit20;
+    // we can run into trouble if the 18 character prefix is greater than the prefix of the
+    // maximum uint64, or the remaining two digits will make the number overflow
+    // Reminder, largest uint64 is 18446744073709551615
+    if (left > 184467440737095516L || (left == 184467440737095516L && right > 15)) {
+      throw new NumberFormatException("out of range for uint64: " + input);
+    }
+    return left * 100 + right; // we are safe!
+  }
+
+  private static int digitAt(String input, int position) {
+    if (input.length() <= position) throw new NumberFormatException("position out of bounds");
+
+    switch (input.charAt(position)) {
+      case '0' : return 0;
+      case '1' : return 1;
+      case '2' : return 2;
+      case '3' : return 3;
+      case '4' : return 4;
+      case '5' : return 5;
+      case '6' : return 6;
+      case '7' : return 7;
+      case '8' : return 8;
+      case '9' : return 9;
+      default: throw new NumberFormatException("char at position " + position + "("
+              + input.charAt(position) + ") isn't a number");
+    }
   }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -18,6 +18,7 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class XCloudTraceContextExtractorTest {
 
@@ -105,5 +106,27 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(-4642722851447643899L);
+  }
+
+  @Test
+  public void parseUnsignedLong() {
+    // max int64
+    assertThat(XCloudTraceContextExtractor.parseUnsignedLong("9223372036854775807"))
+            .isEqualTo(Long.parseUnsignedLong("9223372036854775807"));
+
+    // max int64 + 1
+    assertThat(XCloudTraceContextExtractor.parseUnsignedLong("9223372036854775808"))
+            .isEqualTo(Long.parseUnsignedLong("9223372036854775808"));
+
+    // max uint64
+    assertThat(XCloudTraceContextExtractor.parseUnsignedLong("18446744073709551615"))
+            .isEqualTo(Long.parseUnsignedLong("18446744073709551615"));
+
+    // max uint64 + 1
+    try {
+      XCloudTraceContextExtractor.parseUnsignedLong("18446744073709551616");
+      failBecauseExceptionWasNotThrown(NumberFormatException.class);
+    } catch (NumberFormatException e) {
+    }
   }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -33,7 +33,7 @@ public class XCloudTraceContextExtractorTest {
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().spanId()).isEqualTo(1L);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class XCloudTraceContextExtractorTest {
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().spanId()).isEqualTo(1L);
   }
 
   @Test
@@ -87,6 +87,8 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(1L);
   }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -33,7 +33,7 @@ public class XCloudTraceContextExtractorTest {
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(1L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class XCloudTraceContextExtractorTest {
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(1L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
   }
 
   @Test
@@ -90,5 +90,20 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(1L);
+  }
+
+  @Test
+  public void testExtractXCloudTraceContext_unsignedLong() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/13804021222261907717";
+    XCloudTraceContextExtractor extractor =
+            new XCloudTraceContextExtractor<>(
+                    (StackdriverTracePropagation)
+                            StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING),
+                    (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(-4642722851447643899L);
   }
 }


### PR DESCRIPTION
App Engine generates span IDs that are longer than a long.
Given that Stackdriver Trace doesn't support trace joins, the incoming
span ID is useless anyway.
So, to save the time of parsing and creating a new long object, we don't
do that and, instead, set 1L as the span ID value, which Brave will
always regenerate anyways.