### PR TITLE
Shorten tag/label values that are too large for Stackdriver

### DIFF
--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/LabelExtractorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/LabelExtractorTest.java
@@ -37,10 +37,14 @@ public class LabelExtractorTest {
             .id("5")
             .addAnnotation(1, "annotation.key.1")
             .putTag("tag.key.1", "value")
+            .putTag("long.tag", new String(new char[10000]).replace("\0", "a"))
             .build();
     Map<String, String> labels = extractor.extract(zipkinSpan);
     assertTrue(labels.containsKey("annotation.key.1"));
     assertTrue(labels.containsKey("tag.key.1"));
+    assertTrue(labels.get("tag.key.1").equals("value"));
+    assertTrue(labels.get("long.tag").equals(
+        new String(new char[LabelExtractor.LABEL_LENGTH_MAX]).replace("\0", "a")));
   }
 
   @Test


### PR DESCRIPTION
We had an issue where stackdriver-zipkin (now zipkin-gcp) got stuck in an infinite loop, trying to resend a trace that had a very large SQL statement as a value for one of the tags/labels.

Shorten long tag values to keep within the limits allowed by Stackdriver Trace when extracting labels.
