### PR TITLE
Prefer b3 to x-cloud-trace in extractor

### DIFF
--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -1,6 +1,6 @@
 # propagation-stackdriver
 
-This is a propagation that behaves like `B3Propagation`, but also extracts the tracing context from the 'x-cloud-trace-context' key.
+This is a propagation that behaves like `B3Propagation`, but falls back on tracing context from the 'x-cloud-trace-context' key.
 
 To use it, you can feed it into your tracing system in the following way:
 
@@ -13,7 +13,9 @@ If using Spring Boot auto-configuration, you can also add a dependency to `org.s
 This propagation makes use of the `CompositeExtractor` concept, which attempts to extract the tracing context from multiple extractors.
 At the moment, it doesn't support partial extraction, meaning that if one extractor returns a context that is not empty, that context is returned and the following ones are not ran.
 
-The first attempted extractor is the `XCloudTraceContextExtractor`.
+The first attempted extractor is the `B3Propagation` one, using the `X-B3-TraceId`, `X-B3-SpanId`, etc. keys.
+
+If `B3Propagation` can't find a context, the next extractor is the `XCloudTraceContextExtractor`.
 It checks the `x-cloud-trace-context` key, which is structured in the following way:
 
 `x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE`
@@ -22,11 +24,8 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 * `SPAN_ID`: decimal representation of the unsigned span ID. If 0, it is ignored by Zipkin.
 * `TRACE_TRUE`: `1` if the request should be traced, `0` otherwise.
 
-If `TRACE_TRUE` is absent, the request is traced.
+If `TRACE_TRUE` is absent, the request is traced by default.
 In other words, this extractor will trace keys structured like `x-cloud-trace-context: TRACE_ID/SPAN_ID`.
-
-If `XCloudTraceContextExtractor` can't find a context, the next extractor is the `B3Propagation` one.
-Extraction will proceed using the `X-B3-TraceId`, `X-B3-SpanId`, etc. keys.
 
 # Injector
 

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -22,8 +22,8 @@ import java.util.List;
 /**
  * Stackdriver Trace propagation.
  *
- * <p>Tries to extract a trace ID and span ID using the {@code x-cloud-trace-context} key. If not
- * present, tries the B3 key set, such as {@code X-B3-TraceId}, {@code X-B3-SpanId}, etc.
+ * <p>Tries to extract a trace ID and span ID using the B3 key set, such as {@code X-B3-TraceId}, {@code X-B3-SpanId},
+ * etc. If not present, tries the {@code x-cloud-trace-context} key.
  *
  * <p>Uses {@link B3Propagation} injection, to inject the tracing context using B3 headers.
  */
@@ -83,6 +83,6 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
   @Override public <C> TraceContext.Extractor<C> extractor(Getter<C, K> getter) {
     if (getter == null) throw new NullPointerException("getter == null");
     return CompositeExtractor.create(
-        new XCloudTraceContextExtractor<>(this, getter), b3Propagation.extractor(getter));
+            b3Propagation.extractor(getter), new XCloudTraceContextExtractor<>(this, getter));
   }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
@@ -24,49 +24,51 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StackdriverTracePropagationTest {
-  private static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
-  private static final String B3_HEADER = "b3";
-  private static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
-  private static final String B3_VALUE = String.format("%s-00f067aa0ba902b7-1", B3_TRACE_ID);
+  static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
+  static final String B3_HEADER = "b3";
+  static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
+  static final String B3_VALUE =  B3_TRACE_ID + "-00f067aa0ba902b7-1";
 
-  private Propagation<String> propagation =
+  Propagation<String> propagation =
       StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
+  TraceContext.Extractor<Map<String,String>> extractor = propagation.extractor(Map::get);
 
   @Test
   public void b3TakesPrecedenceOverXCloud() {
-    TraceContext.Extractor<String> extractor =
-        propagation.extractor(new FakeGetter(XCLOUD_VALUE, B3_VALUE));
-    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put(StackdriverTracePropagation.TRACE_ID_NAME, XCLOUD_VALUE);
+    headers.put(B3_HEADER, B3_VALUE);
+
+    TraceContextOrSamplingFlags ctx = extractor.extract(headers);
+
     assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
   }
 
   @Test
   public void xCloudReturnedWhenB3Missing() {
-    TraceContext.Extractor<String> extractor =
-        propagation.extractor(new FakeGetter(XCLOUD_VALUE, null));
-    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+    Map<String, String> headers = new HashMap<>();
+    headers.put(StackdriverTracePropagation.TRACE_ID_NAME, XCLOUD_VALUE);
+
+    TraceContextOrSamplingFlags ctx = extractor.extract(headers);
+
     assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_VALUE);
   }
 
   @Test
   public void b3ReturnedWhenXCloudMissing() {
-    TraceContext.Extractor<String> extractor =
-        propagation.extractor(new FakeGetter(null, B3_VALUE));
-    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+    Map<String, String> headers = new HashMap<>();
+    headers.put(B3_HEADER, B3_VALUE);
+
+    TraceContextOrSamplingFlags ctx = extractor.extract(headers);
+
     assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
   }
 
-  private static class FakeGetter implements Propagation.Getter<String, String> {
-    private Map<String, String> values = new HashMap<>();
+  @Test
+  public void emptyContextReturnedWhenNoHeadersPresent() {
+    TraceContextOrSamplingFlags ctx = extractor.extract(new HashMap<>());
 
-    FakeGetter(String xCloudValue, String b3Value) {
-      this.values.put(StackdriverTracePropagation.TRACE_ID_NAME, xCloudValue);
-      this.values.put(B3_HEADER, b3Value);
-    }
-
-    @Override
-    public String get(String carrier, String key) {
-      return values.get(key);
-    }
+    assertThat(ctx).isSameAs(TraceContextOrSamplingFlags.EMPTY);
   }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
@@ -24,45 +24,49 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StackdriverTracePropagationTest {
-	private static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
-	private static final String B3_HEADER = "b3";
-	private static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
-	private static final String B3_VALUE = String.format("%s-00f067aa0ba902b7-1", B3_TRACE_ID);
+  private static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
+  private static final String B3_HEADER = "b3";
+  private static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
+  private static final String B3_VALUE = String.format("%s-00f067aa0ba902b7-1", B3_TRACE_ID);
 
-	private Propagation<String> propagation = StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
+  private Propagation<String> propagation =
+      StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
 
-	@Test
-	public void b3TakesPrecedenceOverXCloud() {
-		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(XCLOUD_VALUE, B3_VALUE));
-		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
-		assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
-	}
+  @Test
+  public void b3TakesPrecedenceOverXCloud() {
+    TraceContext.Extractor<String> extractor =
+        propagation.extractor(new FakeGetter(XCLOUD_VALUE, B3_VALUE));
+    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+    assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
+  }
 
-	@Test
-	public void xCloudReturnedWhenB3Missing() {
-		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(XCLOUD_VALUE, null));
-		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
-		assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_VALUE);
-	}
+  @Test
+  public void xCloudReturnedWhenB3Missing() {
+    TraceContext.Extractor<String> extractor =
+        propagation.extractor(new FakeGetter(XCLOUD_VALUE, null));
+    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+    assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_VALUE);
+  }
 
-	@Test
-	public void b3ReturnedWhenXCloudMissing() {
-		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(null, B3_VALUE));
-		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
-		assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
-	}
+  @Test
+  public void b3ReturnedWhenXCloudMissing() {
+    TraceContext.Extractor<String> extractor =
+        propagation.extractor(new FakeGetter(null, B3_VALUE));
+    TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+    assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
+  }
 
-	private static class FakeGetter implements Propagation.Getter<String,String> {
-		private Map<String,String> values = new HashMap<>();
+  private static class FakeGetter implements Propagation.Getter<String, String> {
+    private Map<String, String> values = new HashMap<>();
 
-		FakeGetter(String xCloudValue, String b3Value) {
-			this.values.put(StackdriverTracePropagation.TRACE_ID_NAME, xCloudValue);
-			this.values.put(B3_HEADER, b3Value);
-		}
+    FakeGetter(String xCloudValue, String b3Value) {
+      this.values.put(StackdriverTracePropagation.TRACE_ID_NAME, xCloudValue);
+      this.values.put(B3_HEADER, b3Value);
+    }
 
-		@Override
-		public String get(String carrier, String key) {
-			return values.get(key);
-		}
-	}
+    @Override
+    public String get(String carrier, String key) {
+      return values.get(key);
+    }
+  }
 }

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.propagation.stackdriver;
+
+import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
+import brave.propagation.TraceContextOrSamplingFlags;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StackdriverTracePropagationTest {
+	private static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
+	private static final String B3_HEADER = "b3";
+	private static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
+	private static final String B3_VALUE = String.format("%s-00f067aa0ba902b7-1", B3_TRACE_ID);
+
+	private Propagation<String> propagation = StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING);
+
+	@Test
+	public void b3TakesPrecedenceOverXCloud() {
+		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(XCLOUD_VALUE, B3_VALUE));
+		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+		assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
+	}
+
+	@Test
+	public void xCloudReturnedWhenB3Missing() {
+		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(XCLOUD_VALUE, null));
+		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+		assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_VALUE);
+	}
+
+	@Test
+	public void b3ReturnedWhenXCloudMissing() {
+		TraceContext.Extractor<String> extractor = propagation.extractor(new FakeGetter(null, B3_VALUE));
+		TraceContextOrSamplingFlags ctx = extractor.extract("unused object");
+		assertThat(ctx.context().traceIdString()).isEqualTo(B3_TRACE_ID);
+	}
+
+	private static class FakeGetter implements Propagation.Getter<String,String> {
+		private Map<String,String> values = new HashMap<>();
+
+		FakeGetter(String xCloudValue, String b3Value) {
+			this.values.put(StackdriverTracePropagation.TRACE_ID_NAME, xCloudValue);
+			this.values.put(B3_HEADER, b3Value);
+		}
+
+		@Override
+		public String get(String carrier, String key) {
+			return values.get(key);
+		}
+	}
+}


### PR DESCRIPTION
Addresses mismatch between extractor (which used to prefer X-cloud headers) and injector (which propagates b3 headers) by preferring b3 headers, when available.

Fixes #96 .