### PR TITLE
Handle the TRACE_TRUE option in GCP trace header

### DIFF
--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -53,10 +53,11 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       // Try to parse the trace IDs into the context
       TraceContext.Builder context = TraceContext.newBuilder();
       long[] traceId = convertHexTraceIdToLong(tokens[0]);
+
       // traceId is null if invalid
       if (traceId != null) {
         String spanId = "1";
-        Boolean traceTrue = null;
+        Boolean traceTrue = null; // null means to defer trace decision to sampler
 
         // A span ID exists. A TRACE_TRUE flag also possibly exists.
         if (tokens.length >= 2) {

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -63,8 +63,8 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
           String[] traceOptionTokens = tokens[1].split(";");
 
           if (traceOptionTokens.length >= 1 && !traceOptionTokens[0].isEmpty()) {
-						spanId = traceOptionTokens[0];
-					}
+            spanId = traceOptionTokens[0];
+          }
 
           if (traceOptionTokens.length >= 2) {
             traceTrue = extractTraceTrueFromToken(traceOptionTokens[1]);

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -13,11 +13,12 @@
  */
 package zipkin2.propagation.stackdriver;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 
@@ -37,7 +38,7 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
   /**
    * Creates a tracing context if the extracted string follows the "x-cloud-trace-context: TRACE_ID"
    * or "x-cloud-trace-context: TRACE_ID/SPAN_ID" format; or the "x-cloud-trace-context:
-   * TRACE_ID/SPAN_ID;0=TRACE_TRUE" format and {@code TRACE_TRUE}'s value is {@code 1}.
+   * TRACE_ID/SPAN_ID;o=TRACE_TRUE" format and {@code TRACE_TRUE}'s value is {@code 1}.
    */
   @Override public TraceContextOrSamplingFlags extract(C carrier) {
     if (carrier == null) throw new NullPointerException("carrier == null");
@@ -54,32 +55,38 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       long[] traceId = convertHexTraceIdToLong(tokens[0]);
       // traceId is null if invalid
       if (traceId != null) {
-        boolean traceTrue = true;
-
         String spanId = "1";
+        Boolean traceTrue = null;
+
         // A span ID exists. A TRACE_TRUE flag also possibly exists.
         if (tokens.length >= 2) {
-          int semicolonPos = tokens[1].indexOf(";");
-          spanId = semicolonPos == -1 ? tokens[1] : tokens[1].substring(0, semicolonPos);
-          traceTrue = semicolonPos == -1
-              || tokens[1].length() == semicolonPos + 4
-              && tokens[1].charAt(semicolonPos + 3) == '1';
+          String[] traceOptionTokens = tokens[1].split(";");
+
+          if (traceOptionTokens.length >= 1 && !traceOptionTokens[0].isEmpty()) {
+						spanId = traceOptionTokens[0];
+					}
+
+          if (traceOptionTokens.length >= 2) {
+            traceTrue = extractTraceTrueFromToken(traceOptionTokens[1]);
+          }
         }
 
-        if (traceTrue) {
-          result = TraceContextOrSamplingFlags.create(
-              context.traceIdHigh(traceId[0])
-                  .traceId(traceId[1])
-                  .spanId(parseUnsignedLong(spanId))
-                  .build());
+        context = context.traceIdHigh(traceId[0])
+            .traceId(traceId[1])
+            .spanId(parseUnsignedLong(spanId));
+
+        if (traceTrue != null) {
+          context = context.sampled(traceTrue);
         }
+
+        result = TraceContextOrSamplingFlags.create(context.build());
       }
     }
 
     return result;
   }
 
-  static long[] convertHexTraceIdToLong(String hexTraceId) {
+  private static long[] convertHexTraceIdToLong(String hexTraceId) {
     long[] result = new long[2];
     int length = hexTraceId.length();
 
@@ -139,6 +146,32 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       throw new NumberFormatException("out of range for uint64: " + input);
     }
     return left * 100 + right; // we are safe!
+  }
+
+  /**
+   * Parses the TRACE_TRUE from the header token substring in the form: 'o=TRACE_TRUE'.
+   *
+   * @return Optional containing the Span ID if present.
+   */
+  private static Boolean extractTraceTrueFromToken(String traceTrueToken) {
+    int equalsIndex = traceTrueToken.indexOf("=");
+
+    Boolean result = null;
+
+    if (equalsIndex != -1) {
+      String optionName = traceTrueToken.substring(0, equalsIndex);
+      String traceTrueValue = traceTrueToken.substring(equalsIndex + 1, traceTrueToken.length());
+
+      if (optionName.equalsIgnoreCase("o")) {
+        if (traceTrueValue.equals("1")) {
+          result = true;
+        } else if (traceTrueValue.equals("0")) {
+          result = false;
+        }
+      }
+    }
+
+    return result;
   }
 
   private static int digitAt(String input, int position) {

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -35,6 +35,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isTrue();
   }
 
   @Test
@@ -47,11 +48,11 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(context.context().sampled()).isFalse();
   }
 
   @Test
-  public void testExtractXCloudTraceContext_invalidTraceTrue() {
+  public void testExtractXCloudTraceContext_missingTraceTrueValue() {
     String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=";
     XCloudTraceContextExtractor extractor =
         new XCloudTraceContextExtractor<>(
@@ -60,7 +61,10 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -76,6 +80,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -91,6 +96,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(1L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -106,6 +112,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(-4642722851447643899L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test


### PR DESCRIPTION
This adds support to process the TRACE_TRUE option to behave like x-b3-sampled header.

Given a trace of form: `x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE`

If TRACE_TRUE
- is `true`: Force the request to be traced
- is `false`: Force the request not to be traced
- is not present: Defer the trace/no-trace decision to the sampler

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/749

@meltsufin @elefeint PTAL