### PR TITLE
Cleanup Cloud Trace Context Extractor

### DIFF
--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -24,8 +24,13 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 * `SPAN_ID`: decimal representation of the unsigned span ID.
 * `TRACE_TRUE`: `1` if the request should be traced, `0` otherwise.
 
-If `TRACE_TRUE` is absent, the request is traced by default.
-In other words, this extractor will trace keys structured like `x-cloud-trace-context: TRACE_ID/SPAN_ID`.
+### Notes
+
+- One may also choose to omit the span ID by setting it to `0`: `TRACE_ID/0;o=TRACE_TRUE`.
+  In this case, the span ID will default to being the lower 64-bits of the trace ID.
+
+- If `TRACE_TRUE` is absent, then the sampler will determine whether the request is traced or not.
+
 
 # Injector
 

--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -26,7 +26,7 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 
 ### Notes
 
-- One may also choose to omit the span ID by setting it to `0`: `TRACE_ID/0;o=TRACE_TRUE`.
+- One may also choose to omit the span ID by setting it to 0 like this: `TRACE_ID/0;o=TRACE_TRUE`.
   In this case, the span ID will default to being the lower 64-bits of the trace ID.
 
 - If `TRACE_TRUE` is absent, then the sampler will determine whether the request is traced or not.

--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -29,7 +29,7 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 - One may also choose to omit the span ID by setting it to 0 like this: `TRACE_ID/0;o=TRACE_TRUE`.
   In this case, the span ID will default to being the lower 64-bits of the trace ID.
 
-- If `TRACE_TRUE` is absent, then the sampler will determine whether the request is traced or not.
+- If `TRACE_TRUE` is omitted, then the decision to trace the request will be deferred to the sampler.
 
 
 # Injector

--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -27,7 +27,7 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 ### Notes
 
 - One may also choose to omit the span ID by setting it to 0 like this: `TRACE_ID/0;o=TRACE_TRUE`.
-  In this case, the span ID will default to being the lower 64-bits of the trace ID.
+  In this case, a new root span will be generated for the request.
 
 - If `TRACE_TRUE` is omitted, then the decision to trace the request will be deferred to the sampler.
 

--- a/propagation-stackdriver/README.md
+++ b/propagation-stackdriver/README.md
@@ -21,7 +21,7 @@ It checks the `x-cloud-trace-context` key, which is structured in the following 
 `x-cloud-trace-context: TRACE_ID/SPAN_ID;o=TRACE_TRUE`
 
 * `TRACE_ID`: a 32-character hexadecimal value representing a 128-bit number.
-* `SPAN_ID`: decimal representation of the unsigned span ID. If 0, it is ignored by Zipkin.
+* `SPAN_ID`: decimal representation of the unsigned span ID.
 * `TRACE_TRUE`: `1` if the request should be traced, `0` otherwise.
 
 If `TRACE_TRUE` is absent, the request is traced by default.

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -164,11 +164,11 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
     if (optionIndex != -1) {
       String traceTrueValue = traceTrueToken.substring(optionIndex + 2, traceTrueToken.length());
 
-			if (traceTrueValue.equals("1")) {
-				result = true;
-			} else if (traceTrueValue.equals("0")) {
-				result = false;
-			}
+      if (traceTrueValue.equals("1")) {
+        result = true;
+      } else if (traceTrueValue.equals("0")) {
+        result = false;
+      }
     }
 
     return result;

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -53,10 +53,11 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       // Try to parse the trace IDs into the context
       TraceContext.Builder context = TraceContext.newBuilder();
       long[] traceId = convertHexTraceIdToLong(tokens[0]);
+
       // traceId is null if invalid
       if (traceId != null) {
         String spanId = "1";
-        Boolean traceTrue = null;
+        Boolean traceTrue = null; // null means to defer trace decision to sampler
 
         // A span ID exists. A TRACE_TRUE flag also possibly exists.
         if (tokens.length >= 2) {

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -63,8 +63,8 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
           String[] traceOptionTokens = tokens[1].split(";");
 
           if (traceOptionTokens.length >= 1 && !traceOptionTokens[0].isEmpty()) {
-						spanId = traceOptionTokens[0];
-					}
+            spanId = traceOptionTokens[0];
+          }
 
           if (traceOptionTokens.length >= 2) {
             traceTrue = extractTraceTrueFromToken(traceOptionTokens[1]);

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -161,12 +161,12 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
 
     Boolean result = null;
 
-    if (optionIndex != -1) {
-      String traceTrueValue = traceTrueToken.substring(optionIndex + 2, traceTrueToken.length());
+    if (optionIndex != -1 && optionIndex + 2 < traceTrueToken.length()) {
+      char traceTrueOption = traceTrueToken.charAt(optionIndex + 2);
 
-      if (traceTrueValue.equals("1")) {
+      if (traceTrueOption == '1') {
         result = true;
-      } else if (traceTrueValue.equals("0")) {
+      } else if (traceTrueOption == '0') {
         result = false;
       }
     }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -65,7 +65,7 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
 
           if (traceOptionTokens.length >= 1
               && !traceOptionTokens[0].isEmpty()
-              && !traceOptionTokens.equals("0")) {
+              && !traceOptionTokens[0].equals("0")) {
             spanId = parseUnsignedLong(traceOptionTokens[0]);
           }
 

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -13,11 +13,12 @@
  */
 package zipkin2.propagation.stackdriver;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
 
@@ -37,7 +38,7 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
   /**
    * Creates a tracing context if the extracted string follows the "x-cloud-trace-context: TRACE_ID"
    * or "x-cloud-trace-context: TRACE_ID/SPAN_ID" format; or the "x-cloud-trace-context:
-   * TRACE_ID/SPAN_ID;0=TRACE_TRUE" format and {@code TRACE_TRUE}'s value is {@code 1}.
+   * TRACE_ID/SPAN_ID;o=TRACE_TRUE" format and {@code TRACE_TRUE}'s value is {@code 1}.
    */
   @Override public TraceContextOrSamplingFlags extract(C carrier) {
     if (carrier == null) throw new NullPointerException("carrier == null");
@@ -54,32 +55,38 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       long[] traceId = convertHexTraceIdToLong(tokens[0]);
       // traceId is null if invalid
       if (traceId != null) {
-        boolean traceTrue = true;
-
         String spanId = "1";
+        Boolean traceTrue = null;
+
         // A span ID exists. A TRACE_TRUE flag also possibly exists.
         if (tokens.length >= 2) {
-          int semicolonPos = tokens[1].indexOf(";");
-          spanId = semicolonPos == -1 ? tokens[1] : tokens[1].substring(0, semicolonPos);
-          traceTrue = semicolonPos == -1
-              || tokens[1].length() == semicolonPos + 4
-              && tokens[1].charAt(semicolonPos + 3) == '1';
+          String[] traceOptionTokens = tokens[1].split(";");
+
+          if (traceOptionTokens.length >= 1 && !traceOptionTokens[0].isEmpty()) {
+						spanId = traceOptionTokens[0];
+					}
+
+          if (traceOptionTokens.length >= 2) {
+            traceTrue = extractTraceTrueFromToken(traceOptionTokens[1]);
+          }
         }
 
-        if (traceTrue) {
-          result = TraceContextOrSamplingFlags.create(
-              context.traceIdHigh(traceId[0])
-                  .traceId(traceId[1])
-                  .spanId(parseUnsignedLong(spanId))
-                  .build());
+        context = context.traceIdHigh(traceId[0])
+            .traceId(traceId[1])
+            .spanId(parseUnsignedLong(spanId));
+
+        if (traceTrue != null) {
+          context = context.sampled(traceTrue);
         }
+
+        result = TraceContextOrSamplingFlags.create(context.build());
       }
     }
 
     return result;
   }
 
-  static long[] convertHexTraceIdToLong(String hexTraceId) {
+  private static long[] convertHexTraceIdToLong(String hexTraceId) {
     long[] result = new long[2];
     int length = hexTraceId.length();
 
@@ -139,6 +146,32 @@ final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<
       throw new NumberFormatException("out of range for uint64: " + input);
     }
     return left * 100 + right; // we are safe!
+  }
+
+  /**
+   * Parses the TRACE_TRUE from the header token substring in the form: 'o=TRACE_TRUE'.
+   *
+   * @return Optional containing the Span ID if present.
+   */
+  private static Boolean extractTraceTrueFromToken(String traceTrueToken) {
+    int equalsIndex = traceTrueToken.indexOf("=");
+
+    Boolean result = null;
+
+    if (equalsIndex != -1) {
+      String optionName = traceTrueToken.substring(0, equalsIndex);
+      String traceTrueValue = traceTrueToken.substring(equalsIndex + 1, traceTrueToken.length());
+
+      if (optionName.equalsIgnoreCase("o")) {
+        if (traceTrueValue.equals("1")) {
+          result = true;
+        } else if (traceTrueValue.equals("0")) {
+          result = false;
+        }
+      }
+    }
+
+    return result;
   }
 
   private static int digitAt(String input, int position) {

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/StackdriverTracePropagationTest.java
@@ -13,18 +13,20 @@
  */
 package zipkin2.propagation.stackdriver;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StackdriverTracePropagationTest {
-  static final String XCLOUD_VALUE = "c108dc108dc108dc108dc108dc108d00";
+  static final String XCLOUD_TRACE_ID = "c108dc108dc108dc108dc108dc108d00";
+  static final String XCLOUD_VALUE = XCLOUD_TRACE_ID + "/1234";
+
   static final String B3_HEADER = "b3";
   static final String B3_TRACE_ID = "b3b3b3b3b3b34da6a3ce929d0e0e4736";
   static final String B3_VALUE =  B3_TRACE_ID + "-00f067aa0ba902b7-1";
@@ -52,7 +54,7 @@ public class StackdriverTracePropagationTest {
 
     TraceContextOrSamplingFlags ctx = extractor.extract(headers);
 
-    assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_VALUE);
+    assertThat(ctx.context().traceIdString()).isEqualTo(XCLOUD_TRACE_ID);
   }
 
   @Test

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -95,7 +95,7 @@ public class XCloudTraceContextExtractorTest {
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(1L);
+    assertThat(context.context().spanId()).isEqualTo(context.context().traceId());
     assertThat(context.context().sampled()).isNull();
   }
 

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -48,10 +48,9 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
-    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(-7348336952112078057L);
-    assertThat(context.context().sampled()).isTrue();
+    assertThat(context.traceIdContext().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.traceIdContext().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.traceIdContext().sampled()).isTrue();
   }
 
   @Test
@@ -109,10 +108,9 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
-    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
-    assertThat(context.context().spanId()).isEqualTo(context.context().traceId());
-    assertThat(context.context().sampled()).isNull();
+    assertThat(context.traceIdContext().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.traceIdContext().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.traceIdContext().sampled()).isNull();
   }
 
   @Test

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -35,6 +35,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isTrue();
   }
 
   @Test
@@ -47,11 +48,11 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(context.context().sampled()).isFalse();
   }
 
   @Test
-  public void testExtractXCloudTraceContext_invalidTraceTrue() {
+  public void testExtractXCloudTraceContext_missingTraceTrueValue() {
     String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=";
     XCloudTraceContextExtractor extractor =
         new XCloudTraceContextExtractor<>(
@@ -60,7 +61,10 @@ public class XCloudTraceContextExtractorTest {
             (carrier, key) -> xCloudTraceContext);
 
     TraceContextOrSamplingFlags context = extractor.extract(new Object());
-    assertThat(context).isEqualTo(TraceContextOrSamplingFlags.EMPTY);
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -76,6 +80,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(4981115762139876185L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -91,6 +96,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(1L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test
@@ -106,6 +112,7 @@ public class XCloudTraceContextExtractorTest {
     assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
     assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
     assertThat(context.context().spanId()).isEqualTo(-4642722851447643899L);
+    assertThat(context.context().sampled()).isNull();
   }
 
   @Test

--- a/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -39,6 +39,22 @@ public class XCloudTraceContextExtractorTest {
   }
 
   @Test
+  public void testExtractXCloudTraceContext_spanIdZero() {
+    String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/0;o=1";
+    XCloudTraceContextExtractor extractor =
+        new XCloudTraceContextExtractor<>(
+            (StackdriverTracePropagation)
+                StackdriverTracePropagation.FACTORY.create(Propagation.KeyFactory.STRING),
+            (carrier, key) -> xCloudTraceContext);
+
+    TraceContextOrSamplingFlags context = extractor.extract(new Object());
+    assertThat(context.context().traceId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().traceIdHigh()).isEqualTo(-8081649345970823455L);
+    assertThat(context.context().spanId()).isEqualTo(-7348336952112078057L);
+    assertThat(context.context().sampled()).isTrue();
+  }
+
+  @Test
   public void testExtractXCloudTraceContext_traceFalse() {
     String xCloudTraceContext = "8fd836bcfe241ee19a057679a77ba317/4981115762139876185;o=0";
     XCloudTraceContextExtractor extractor =


### PR DESCRIPTION
This cleans up the XCloudTraceContextExtractor following up from #103.

I made a few changes here:
- Instead of setting a default span ID of 1, I set it to 0.

- You can now pass in x-cloud-trace-context in the form of `TRACE_ID/0;o=1`. If 0 is passed in, we wil interpret this as omitting a span ID by returning a `TraceIdContext` object, which reflects the intention described in [Stackdriver docs](https://cloud.google.com/trace/docs/troubleshooting) see section "How do I force a request to be traced?" 

  > SPAN_ID is the decimal representation of the (unsigned) span ID. It should be 0 for the first span in your trace. 

- cleans up the 'o=' options parsing as mentioned in #103.

PTAL @meltsufin 