### PR TITLE
Update README

### DIFF
--- a/autoconfigure/storage-stackdriver/README.md
+++ b/autoconfigure/storage-stackdriver/README.md
@@ -70,7 +70,7 @@ java -Dloader.path=stackdriver -Dspring.profiles.active=stackdriver -cp zipkin.j
 
 Once your storage is enabled, verify it is running:
 ```bash
-$ curl -s localhost:9411/health|jq .zipkin.StackdriverStorage
+$ curl -s localhost:9411/health|jq .zipkin.details.StackdriverStorage
 {
   "status": "UP"
 }


### PR DESCRIPTION
When hitting the health endpoint, the JSON returned includes a details key in the zipkin object.  The details object is what includes the StackdriverStorage object so this updates the argument passed to `jq` so that the status for StackdriverStorage is returned.