### PR TITLE
Use UnaryGrpcClient in storage-stackdriver instead of gRPC stubs.

### DIFF
--- a/autoconfigure/storage-stackdriver/pom.xml
+++ b/autoconfigure/storage-stackdriver/pom.xml
@@ -47,6 +47,18 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-trace-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria-grpc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageAutoConfiguration.java
+++ b/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import zipkin2.Call;
 import zipkin2.storage.StorageComponent;
 import zipkin2.storage.stackdriver.StackdriverStorage;
 
@@ -59,6 +60,7 @@ public class ZipkinStackdriverStorageAutoConfiguration {
     try {
       return getDefaultProjectId();
     } catch (Throwable t) {
+      Call.propagateIfFatal(t);
       throw new IllegalArgumentException("Missing required property: projectId");
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -167,11 +167,18 @@
       </dependency>
 
       <dependency>
+        <groupId>com.linecorp.armeria</groupId>
+        <artifactId>armeria-bom</artifactId>
+        <version>${armeria.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-trace-v2</artifactId>
         <version>${grpc-google-cloud-trace-v2.version}</version>
         <exclusions>
-          <!-- let collector (armeria) or sender (grpc) control the protobuf versions -->
           <exclusion>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
@@ -188,9 +195,32 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-trace-v2</artifactId>
+        <version>${grpc-google-cloud-trace-v2.version}</version>
+        <exclusions>
+          <!-- let collector (armeria) or sender (grpc) control the protobuf versions -->
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.api</groupId>
+            <artifactId>api-common</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/storage-stackdriver/pom.xml
+++ b/storage-stackdriver/pom.xml
@@ -44,22 +44,37 @@
 
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
-      <artifactId>armeria-grpc</artifactId>
-      <!-- Not using armeria BOM as zipkin-server + grpc-google-cloud-trace-v2 disagree on deps -->
-      <version>${armeria.version}</version>
+      <artifactId>armeria-grpc-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-cloud-trace-v2</artifactId>
+      <artifactId>proto-google-cloud-trace-v2</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria-grpc</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
       <artifactId>armeria-testing-junit4</artifactId>
-      <version>${armeria.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-trace-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/storage-stackdriver/pom.xml
+++ b/storage-stackdriver/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>zipkin-gcp-parent</artifactId>
     <groupId>io.zipkin.gcp</groupId>
@@ -86,4 +88,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/translation-stackdriver/pom.xml
+++ b/translation-stackdriver/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-trace-v2</artifactId>
-      <version>${grpc-google-cloud-trace-v2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Now `storage-stackdriver` doesn't depend on gRPC or guava.

I was a bit unsure what to do with it's protobuf dependency as armeria-grpc-protocol doesn't depend on it so it wouldn't control the version. I've never seen an incompatible API in protobuf before though and recommend just pinning to latest version like here.