### PR TITLE
Updates versions notably to ASF Zipkin

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -20,12 +20,12 @@ import java.util.Properties;
 
 public class MavenWrapperDownloader {
 
-    private static final String WRAPPER_VERSION = "0.5.4";
+    private static final String WRAPPER_VERSION = "0.5.5";
     /**
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */
     private static final String DEFAULT_DOWNLOAD_URL = "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/"
-        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + " .jar";
+        + WRAPPER_VERSION + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
 
     /**
      * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ When submitting code, please apply [Square Code Style](https://github.com/square
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/openzipkin/zipkin/blob/master/LICENSE
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/apache/incubator-zipkin/blob/master/LICENSE
 
 All files are released with the Apache 2.0 license.
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Shared libraries that provide Zipkin integration with the Google Cloud Platform.
 
 # Usage
 These components integrate traced applications and servers through Google Cloud services
-via interfaces defined in [Zipkin](https://github.com/openzipkin/zipkin)
-and [zipkin-reporter-java](https://github.com/openzipkin/zipkin-reporter-java).
+via interfaces defined in [Zipkin](https://github.com/apache/incubator-zipkin)
+and [zipkin-reporter-java](https://github.com/apache/incubator-zipkin-reporter-java).
 
 ## Senders
 The component in an traced application that sends timing data (spans)
 out of process is called a Sender. Senders are called on interval by an
-[async reporter](https://github.com/openzipkin/zipkin-reporter-java#asyncreporter).
+[async reporter](https://github.com/apache/incubator-zipkin-reporter-java#asyncreporter).
 
 NOTE: Applications can be written in any language, while we currently
 only have senders in Java, senders in other languages are welcome.
@@ -53,8 +53,8 @@ Each module will also have different minimum variables that need to be set.
 
 Ex.
 ```
-$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
-$ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-storage-stackdriver:LATEST:module stackdriver.jar
+$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s
+$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-storage-stackdriver:LATEST:module stackdriver.jar
 $ STORAGE_TYPE=stackdriver STACKDRIVER_PROJECT_ID=zipkin-demo \
     java \
     -Dloader.path='stackdriver.jar,stackdriver.jar!/lib' \

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -74,10 +74,14 @@
           </excludeGroupIds>
           <!-- currently cannot exclude io.opencensus due to https://github.com/googleapis/google-http-java-client/issues/621 -->
           <excludes>
-            <!-- zipkin-server depends on armeria -->
+            <!-- zipkin-server depends on armeria and its grpc protocol-->
             <exclude>
               <groupId>com.linecorp.armeria</groupId>
               <artifactId>armeria</artifactId>
+            </exclude>
+            <exclude>
+              <groupId>com.linecorp.armeria</groupId>
+              <artifactId>armeria-grpc-protocol</artifactId>
             </exclude>
             <!-- See https://github.com/line/armeria/issues/1679 -->
             <exclude>

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -70,7 +70,7 @@
         <configuration>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>
-            io.zipkin.zipkin2,io.zipkin.reporter2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,com.google.guava,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils
+            org.apache.zipkin.zipkin2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,com.google.guava,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils
           </excludeGroupIds>
           <!-- currently cannot exclude io.opencensus due to https://github.com/googleapis/google-http-java-client/issues/621 -->
           <excludes>

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -69,8 +69,14 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
+          <!--
+          Not excluding guava right now eventhough there is an overlap to avoid the following conflict
+
+          java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;CLjava/lang/Object;)V
+             at io.grpc.Metadata$Key.validateName(Metadata.java:629) ~[grpc-core-1.20.0.jar!/:1.20.0]
+          -->
           <excludeGroupIds>
-            org.apache.zipkin.zipkin2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,com.google.guava,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils
+            org.apache.zipkin.zipkin2,org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,com.google.code.gson,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils
           </excludeGroupIds>
           <!-- currently cannot exclude io.opencensus due to https://github.com/googleapis/google-http-java-client/issues/621 -->
           <excludes>

--- a/autoconfigure/storage-stackdriver/README.md
+++ b/autoconfigure/storage-stackdriver/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This is a Spring Boot [AutoConfiguration](http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-auto-configuration.html)
-module that can be added to a [Zipkin Server](https://github.com/openzipkin/zipkin/tree/master/zipkin-server) 
+module that can be added to a [Zipkin Server](https://github.com/apache/incubator-zipkin/tree/master/zipkin-server) 
 deployment to send Spans to Google Stackdriver Trace over gRPC transport.
 
 This currently only supports sending to Stackdriver, not reading back spans from the service.
@@ -13,7 +13,7 @@ and exposes configuration options through environment variables.
 ## Experimental
 * Note: This is currently experimental! *
 * Note: This requires reporters send 128-bit trace IDs *
-* Check https://github.com/openzipkin/b3-propagation/issues/6 for tracers that support 128-bit trace IDs
+* Check https://github.com/apache/incubator-zipkin-b3-propagation/issues/6 for tracers that support 128-bit trace IDs
 
 ## Quick start
 
@@ -28,8 +28,8 @@ Run Zipkin server with the StackDriver Storage enabled.
 For example:
 
 ```bash
-$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
-$ curl -sSL https://zipkin.io/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-storage-stackdriver:LATEST:module stackdriver.jar
+$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s
+$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s io.zipkin.java:zipkin-autoconfigure-storage-stackdriver:LATEST:module stackdriver.jar
 $ STORAGE_TYPE=stackdriver STACKDRIVER_PROJECT_ID=zipkin-demo \
     java \
     -Dloader.path='stackdriver.jar,stackdriver.jar!/lib' \
@@ -42,7 +42,7 @@ After executing these steps, applications can send spans
 http://localhost:9411/api/v2/spans (or the legacy endpoint http://localhost:9411/api/v1/spans)
 
 The Zipkin server can be further configured as described in the
-[Zipkin server documentation](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md).
+[Zipkin server documentation](https://github.com/apache/incubator-zipkin/blob/master/zipkin-server/README.md).
 
 ### Configuration
 

--- a/autoconfigure/storage-stackdriver/pom.xml
+++ b/autoconfigure/storage-stackdriver/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>0.13.0</version>
+      <version>0.15.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -44,6 +44,13 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-sender-stackdriver</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <!-- TODO remove when reporter is on ASF group ID -->
+        <exclusion>
+          <groupId>io.zipkin.zipkin2</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/mvnw
+++ b/mvnw
@@ -212,9 +212,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -120,7 +120,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
@@ -134,7 +134,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.4/maven-wrapper-0.5.4.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...

--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@
 
     <!-- matching armeria/grpc/zipkin -->
     <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
-    <armeria.version>0.83.0</armeria.version>
-    <zipkin.version>2.12.8</zipkin.version>
+    <armeria.version>0.84.0</armeria.version>
+    <zipkin.version>2.13.0</zipkin.version>
     <zipkin-reporter.version>2.8.2</zipkin-reporter.version>
     <brave.version>5.6.3</brave.version>
-    <grpc.version>1.19.0</grpc.version>
+    <grpc.version>1.20.0</grpc.version>
     <guava.version>26.0-android</guava.version>
 
     <!-- only used for protos, we could possibly obviate this if a problem -->
-    <grpc-google-cloud-trace-v2.version>0.50.0</grpc-google-cloud-trace-v2.version>
+    <grpc-google-cloud-trace-v2.version>0.56.0</grpc-google-cloud-trace-v2.version>
 
     <assertj.version>3.12.2</assertj.version>
 
@@ -71,8 +71,8 @@
   <inceptionYear>2016</inceptionYear>
 
   <organization>
-    <name>OpenZipkin</name>
-    <url>http://zipkin.io/</url>
+    <name>Apache (Incubating) Zipkin</name>
+    <url>https://zipkin.apache.org/</url>
   </organization>
 
   <licenses>
@@ -94,7 +94,7 @@
   <developers>
     <developer>
       <id>openzipkin</id>
-      <name>OpenZipkin Gitter</name>
+      <name>Apache (Incubating) Zipkin Gitter</name>
       <url>https://gitter.im/openzipkin/zipkin</url>
     </developer>
   </developers>
@@ -115,28 +115,16 @@
     <url>https://github.com/openzipkin/zipkin-gcp/issues</url>
   </issueManagement>
 
-  <repositories>
-    <repository>
-      <!-- temporary until zipkin 2.12.7 is out fixing guava dep version mismatch with grpc -->
-      <id>jfrog-snapshots</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
+        <groupId>org.apache.zipkin.zipkin2</groupId>
         <artifactId>zipkin</artifactId>
         <version>${zipkin.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin</artifactId>
-        <type>test-jar</type>
+        <groupId>org.apache.zipkin.zipkin2</groupId>
+        <artifactId>zipkin-tests</artifactId>
         <version>${zipkin.version}</version>
       </dependency>
 
@@ -160,6 +148,9 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <!-- Up to v2.27.0 of mockito has a conflict https://github.com/mockito/mockito/issues/1606
+        java.lang.NoSuchMethodError: net.bytebuddy.dynamic.loading.MultipleParentClassLoader$Builder.appendMostSpecific(Ljava/util/Collection;)Lnet/bytebuddy/dynamic/loading/MultipleParentClassLoader$Builder
+        -->
         <version>2.23.4</version>
       </dependency>
       <dependency>
@@ -205,11 +196,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -237,15 +223,15 @@
         <plugin>
           <groupId>io.takari</groupId>
           <artifactId>maven</artifactId>
-          <version>0.7.5</version>
+          <version>0.7.6</version>
           <configuration>
-            <maven>3.6.0</maven>
+            <maven>3.6.1</maven>
           </configuration>
         </plugin>
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
           <inherited>true</inherited>
           <configuration>
             <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
@@ -275,9 +261,9 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>io.zipkin.layout</groupId>
+              <groupId>org.apache.zipkin.layout</groupId>
               <artifactId>zipkin-layout-factory</artifactId>
-              <version>0.0.4</version>
+              <version>0.0.5</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -305,7 +291,7 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
       </plugin>
 
       <plugin>
@@ -533,7 +519,7 @@
 
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <configuration>
               <failOnError>false</failOnError>
               <!-- hush pedantic warnings: we don't put param and return on everything! -->

--- a/sender-stackdriver/pom.xml
+++ b/sender-stackdriver/pom.xml
@@ -55,9 +55,14 @@
     </dependency>
 
     <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/storage-stackdriver/pom.xml
+++ b/storage-stackdriver/pom.xml
@@ -34,6 +34,10 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-translation-stackdriver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
@@ -56,6 +60,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/translation-stackdriver/pom.xml
+++ b/translation-stackdriver/pom.xml
@@ -31,21 +31,27 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <!-- Provided because reporter is on old group ID -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-trace-v2</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.6.1</version>
+      <version>3.7.1</version>
       <!-- We use provided scope to avoid pinning a protobuf version -->
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin</artifactId>
-      <type>test-jar</type>
+      <groupId>org.apache.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
There is a problem at runtime eventhough grpc-core.jar is inside stackdriver.jar
```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class io.grpc.Status
	at com.linecorp.armeria.internal.grpc.HttpStreamReader.onNext(HttpStreamReader.java:137) ~[armeria-grpc-0.84.0.jar!/:?]
	at com.linecorp.armeria.internal.grpc.HttpStreamReader.onNext(HttpStreamReader.java:52) ~[armeria-grpc-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DeferredStreamMessage$ForwardingSubscriber.onNext(DeferredStreamMessage.java:305) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberWithElements(DefaultStreamMessage.java:342) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber0(DefaultStreamMessage.java:320) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriber(DefaultStreamMessage.java:253) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.addObjectOrEvent(DefaultStreamMessage.java:239) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.addObject(DefaultStreamMessage.java:151) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.AbstractStreamMessageAndWriter.tryWrite(AbstractStreamMessageAndWriter.java:74) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.tryWrite(DefaultStreamMessage.java:65) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.client.DecodedHttpResponse.tryWrite(DecodedHttpResponse.java:55) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.client.HttpResponseDecoder$HttpResponseWrapper.tryWrite(HttpResponseDecoder.java:244) ~[armeria-0.84.0.jar!/:?]
	at com.linecorp.armeria.client.Http2ResponseDecoder.onHeadersRead(Http2ResponseDecoder.java:202) ~[armeria-0.84.0.jar!/:?]
	... 49 more
```