### PR TITLE
Allow running zipkin-gcp on Java 9+ without ALPN

### DIFF
--- a/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageAutoConfiguration.java
+++ b/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageAutoConfiguration.java
@@ -111,8 +111,10 @@ public class ZipkinStackdriverStorageAutoConfiguration {
         return true;
       } catch (Throwable ignore) {
         // alpn-boot was not loaded.
+        return false;
       }
     }
-    return false;
+    // Java 9+ don't need ALPN so we don't even check for it.
+    return true;
   }
 }


### PR DESCRIPTION
Happened to notice this when wanting to copy this code into armeria