### PR TITLE
Adds STACKDRIVER_HTTP_LOGGING=headers to see grpc status

### DIFF
--- a/autoconfigure/storage-stackdriver/README.md
+++ b/autoconfigure/storage-stackdriver/README.md
@@ -58,6 +58,7 @@ for users that prefer a file based approach.
 |GOOGLE_APPLICATION_CREDENTIALS | Optional. [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials). Not managed by spring boot. |
 |STACKDRIVER_PROJECT_ID         | GCP projectId. Optional on GCE. Required on all other platforms. If not provided on GCE, it will default to the projectId associated with the GCE resource. |
 |STACKDRIVER_API_HOST           | host:port combination of the gRPC endpoint. Default: cloudtrace.googleapis.com:443 |
+|STACKDRIVER_HTTP_LOGGING       | When set, controls the volume of HTTP logging of the Stackdriver Trace Api. Options are BASIC and HEADERS |
 
 ### Running
 

--- a/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageProperties.java
+++ b/autoconfigure/storage-stackdriver/src/main/java/zipkin/autoconfigure/storage/stackdriver/ZipkinStackdriverStorageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,9 +19,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("zipkin.storage.stackdriver")
 public class ZipkinStackdriverStorageProperties implements Serializable { // for Spark jobs
   private static final long serialVersionUID = 0L;
+  /**
+   * Sets the level of logging for HTTP requests made by the Stackdriver client. If not set or
+   * none, logging will be disabled.
+   */
+  enum HttpLogging {
+    NONE,
+    BASIC,
+    HEADERS
+  }
 
   private String projectId;
   private String apiHost = "cloudtrace.googleapis.com:443";
+  /** When set, controls the volume of HTTP logging of the Stackdriver Trace Api. */
+  private HttpLogging httpLogging = HttpLogging.NONE;
 
   public String getProjectId() {
     return projectId;
@@ -37,5 +48,13 @@ public class ZipkinStackdriverStorageProperties implements Serializable { // for
 
   public void setApiHost(String apiHost) {
     this.apiHost = "".equals(apiHost) ? null : apiHost;
+  }
+
+  public HttpLogging getHttpLogging() {
+    return httpLogging;
+  }
+
+  public void setHttpLogging(HttpLogging httpLogging) {
+    this.httpLogging = httpLogging;
   }
 }

--- a/autoconfigure/storage-stackdriver/src/main/resources/zipkin-server-stackdriver.yml
+++ b/autoconfigure/storage-stackdriver/src/main/resources/zipkin-server-stackdriver.yml
@@ -4,3 +4,4 @@ zipkin:
     stackdriver:
       api-host: ${STACKDRIVER_API_HOST:cloudtrace.googleapis.com:443}
       project-id: ${STACKDRIVER_PROJECT_ID:}
+      http-logging: ${STACKDRIVER_HTTP_LOGGING:}


### PR DESCRIPTION
This makes it easier to see grpc errors as they are in the trailers sometimes.

Use `STACKDRIVER_HTTP_LOGGING=headers` to see grpc status. Note this doesn't include body as it is complicated and also it is binary. You can still see grpc errors looking only at the headers.

Ex. `Requested entity was not found.` when you misconfigure the application name

```
2019-08-16 10:45:29.036  INFO 47885 --- [-worker-nio-2-4] c.l.a.c.l.LoggingClient                  : Request: {startTime=2019-08-16T02:45:29.023Z(1565923529023099), length=399B, duration=10424µs(10424447ns), scheme=none+h2, headers=[:method=POST, :path=/google.devtools.cloudtrace.v2.TraceService/BatchWriteSpans, :authority=cloudtrace.googleapis.com, :scheme=https, te=trailers, content-length=399, authorization=Bearer REDACTED, content-type=application/grpc, user-agent=armeria/0.90.0]}
2019-08-16 10:45:30.502  INFO 47885 --- [-worker-nio-2-4] c.l.a.c.l.LoggingClient                  : Response: {startTime=2019-08-16T02:45:30.498Z(1565923530498628), length=0B, duration=3806µs(3806088ns), headers=[:status=200, content-type=application/grpc, date=Fri, 16 Aug 2019 02:45:12 GMT, alt-svc=quic=":443"; ma=2592000; v="46,43,39"], trailers=[EOS, grpc-status=5, grpc-message=Requested entity was not found., google.rpc.resourceinfo-bin=EhNwcm9qZWN0cy96aXBraW4tZGV2, grpc-status-details-bin=CAUSH1JlcXVlc3RlZCBlbnRpdHkgd2FzIG5vdCBmb3VuZC4aRAordHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUucnBjLlJlc291cmNlSW5mbxIVEhNwcm9qZWN0cy96aXBraW4tZGV2]}
```

See #133