### PR TITLE
Make serviceName check null-safe

### DIFF
--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
@@ -80,7 +80,9 @@ final class AttributesExtractor {
       }
     }
 
-    if (zipkinSpan.localEndpoint() != null && !zipkinSpan.localEndpoint().serviceName().isEmpty()) {
+    if (zipkinSpan.localEndpoint() != null &&
+        zipkinSpan.localEndpoint().serviceName() != null &&
+        !zipkinSpan.localEndpoint().serviceName().isEmpty()) {
       attributes.putAttributeMap(
           kComponentLabelKey, toAttributeValue(zipkinSpan.localEndpoint().serviceName()));
     }

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/AttributesExtractorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/AttributesExtractorTest.java
@@ -149,6 +149,24 @@ public class AttributesExtractorTest {
   }
 
   @Test
+  public void testEndpointWithNullServiceName() {
+    Endpoint.Builder serverEndpointBuilder = Endpoint.newBuilder().port(80);
+    Endpoint serverEndpoint = serverEndpointBuilder.build();
+    Span serverSpan =
+        Span.newBuilder()
+            .kind(Kind.SERVER)
+            .traceId("4")
+            .name("test-span")
+            .id("5")
+            .localEndpoint(serverEndpoint)
+            .build();
+
+    AttributesExtractor extractor = new AttributesExtractor(Collections.emptyMap());
+    Map<String, AttributeValue> serverLabels = extractor.extract(serverSpan).getAttributeMapMap();
+    assertThat(serverLabels).doesNotContainKey("endpoint.serviceName");
+  }
+
+  @Test
   public void testComponentLabelIsSet() {
     AttributesExtractor extractor = new AttributesExtractor(Collections.emptyMap());
     Span clientSpan =


### PR DESCRIPTION
Span object stores `localEndpoint.serviceName` empty string as null so `.isEmpty()` throws NullPointerException.