### PR TITLE
Upgrades brave and updates HexCodec import to correct package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <!-- matching armeria/grpc/zipkin -->
     <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
     <zipkin.version>2.21.1</zipkin.version>
-    <zipkin-reporter.version>2.12.3</zipkin-reporter.version>
-    <brave.version>5.11.2</brave.version>
+    <zipkin-reporter.version>2.15.0</zipkin-reporter.version>
+    <brave.version>5.12.3</brave.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>0.99.3</armeria.version>

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -21,7 +21,7 @@ import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 
-import static brave.internal.HexCodec.lenientLowerHexToUnsignedLong;
+import static brave.internal.codec.HexCodec.lenientLowerHexToUnsignedLong;
 
 final class XCloudTraceContextExtractor<C, K> implements TraceContext.Extractor<C> {
 


### PR DESCRIPTION
`spring-cloud-sleuth` is already using the latest version of Brave, but `zipkin-gcp` lagged. 

In between, `HexCodec` helper class got moved into a subpackage in openzipkin/brave#1193.

This PR will allow `spring-cloud-gcp` to upgrade to the latest `spring-cloud-sleuth` without triggering runtime class incompatibility (`Caused by: java.lang.NoClassDefFoundError: brave/internal/HexCodec`).