### PR TITLE
Re-enables license plugin

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -43,6 +43,7 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
       - name: Execute Zipkin GCP Build
+        # Skips tests and license to run faster and allow shallow clones
         run: ./mvnw -T1C -q --batch-mode -DskipTests -Dlicense.skip=true clean package
         shell: bash
         env:

--- a/.github/workflows/docker/docker-compose.test.yml
+++ b/.github/workflows/docker/docker-compose.test.yml
@@ -1,17 +1,3 @@
-#
-# Copyright 2016-2019 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
-#
-
 # This file is in the ./docker directory as otherwise it is mistaken for a GitHub Workflow
 
 version: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ arch: amd64           # arm64 is LXD containers which we can't use because we ru
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 
-# Don't do a shallow clone to allow license plugin to correctly read git history.
+# license-maven-plugin needs the full history to generate copyright year range. Ex. 2013-2020
+# Don't do a shallow clone, as it interferes with this.
 git:
   depth: false
 
 language: java
 
-services:
-  - docker
-
 cache:
   directories:
     - $HOME/.m2
+
+services:
+  - docker
 
 before_install:
   - export DOCKER_TARGET=zipkin-gcp
@@ -76,10 +77,10 @@ jobs:
           git push origin :"${TRAVIS_TAG}"
       if: 'type IN (push) and tag =~ /^docker-/'
 
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
 branches:
   except:
-    # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
-    # See https://github.com/travis-ci/travis-ci/issues/1532
     - /^[0-9]/
 
 notifications:
@@ -89,7 +90,6 @@ notifications:
       - https://webhooks.gitter.im/e/9f1ee2f315d32956f8d6
     on_success: change
     on_failure: always
-
 
 # Secure variables needed for release and publication
 #

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
    Release automation invokes [`travis/publish.sh`](travis/publish.sh), which does the following:
      * Creates commits, N.N.N tag, and increments the version (maven-release-plugin)
      * Publishes jars to https://oss.sonatype.org/service/local/staging/deploy/maven2 (maven-deploy-plugin)
-       * Upon close, this synchronizes jars to Maven Central
+       * Upon close, this synchronizes jars to Maven Central (nexus-staging-maven-plugin)
      * Invokes [DockerHub](docker/RELEASE.md] build (docker/bin/push_all_images)
 
    Notes:
@@ -60,7 +60,7 @@ $ ./mvnw versions:set -DnewVersion=1.3.2-SNAPSHOT -DgenerateBackupPoms=false
 $ git commit -am"Adjusts copyright headers for this year"
 ```
 
-### Manually releasing
+## Manually releasing
 
 If for some reason, you lost access to CI or otherwise cannot get automation to work, bear in mind
 this is a normal maven project, and can be released accordingly.
@@ -76,7 +76,7 @@ export SONATYPE_PASSWORD=your_sonatype_password
 VERSION=xx-version-to-release-xx
 
 # now from latest master, prepare the release. We are intentionally deferring pushing commits
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests -Dlicense.skip=true" release:prepare  -DpushChanges=false
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion=$VERSION -Darguments="-DskipTests" release:prepare -DpushChanges=false
 
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION

--- a/docker/build_image
+++ b/docker/build_image
@@ -64,6 +64,7 @@ case "${RELEASE_VERSION}" in
       fi
 
       echo Building ${PROJECT} ${RELEASE_VERSION}...
+      # Skips tests and license to run faster and allow shallow clones
       ./mvnw -T1C -q --batch-mode -DskipTests -Dlicense.skip=true package
     fi
     RELEASE_FROM_MAVEN_BUILD=true

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -119,8 +119,7 @@ if is_release_version; then
   true
 else
   # verify runs both tests and integration tests (Docker tests included)
-  # -Dlicense.skip=true skips license on Travis due to #1512
-  ./mvnw verify -nsu -Dlicense.skip=true
+  ./mvnw verify -nsu
 fi
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
@@ -132,7 +131,7 @@ if is_pull_request; then
 #    Sonatype and try again: https://oss.sonatype.org/#stagingRepositories
 elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests -Dlicense.skip=true deploy
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
   # Regardless of if this is a release build or not, push to corresponding Docker Registries
   RELEASE_FROM_MAVEN_BUILD=true docker/bin/push_all_images $(print_project_version)
@@ -145,6 +144,5 @@ elif is_travis_branch_master; then
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  # skip license on travis due to #1512
-  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi


### PR DESCRIPTION
We've long since gotten to the bottom of this. Rather than always skipping the
license plugin in CI, causing a poor experience for people who have local builds
fail over it, this re-enables after underscoring the CI config needed to make it
work.

After this change, pull requests won't be green unless the headers are correct.