### PR TITLE
Fixes on-demand build in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,10 +4,15 @@
 # Install script runs within Docker
 !build-bin/maven/maven_build
 !build-bin/maven/maven_build_or_unjar
+!build-bin/maven/maven_opts
 !build-bin/maven/maven_unjar
 
-# Allow on-demand "mvn package"
-!**/src/main/**
+# Allow on-demand "mvn package". <modules> referenced in pom.xml must be added even if not built
+!translation-stackdriver/src/main/**
+!sender-stackdriver/src/main/**
+!storage-stackdriver/src/main/**
+!propagation-stackdriver/src/main/**
+!module/src/main/**
 !**/pom.xml
 
 # Allow re-use of built artifacts when using "mvn package"

--- a/build-bin/docker/docker_test_image
+++ b/build-bin/docker/docker_test_image
@@ -20,7 +20,7 @@ set -ue
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 
 # This just makes sure containers run and the HEALTHCHECK works (for now..)
-compose_file=build-bin/docker-compose-$(echo ${docker_image}| cut -f2 -d/).yml
+compose_file=${2:-$(build-bin/docker-compose-$(echo ${docker_image}| cut -f2 -d/)).yml}
 
 if test -f "${compose_file}"; then
   docker-compose -f "${compose_file}" up -d --quiet-pull

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -18,4 +18,4 @@ set -ue
 export MAVEN_OPTS="$($(dirname "$0")/maven_opts)"
 
 (if [ "${MAVEN_PROJECT_BASEDIR:-.}" != "." ]; then cd ${MAVEN_PROJECT_BASEDIR}; fi && \
-mvn -T1C -q --batch-mode -DskipTests package)
+mvn -T1C -q --batch-mode -DskipTests package "$@")

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -58,5 +58,5 @@ esac
 set -ue
 
 echo "*** Building snapshot from source..."
-$(dirname "$0")/maven_build
+$(dirname "$0")/maven_build -pl :${artifact_id} --am
 $(dirname "$0")/maven_unjar $args

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -40,7 +40,7 @@ args="${group_id} ${artifact_id} ${version} ${classifier}"
 # Fail on unset variables, but don't quit on rc!=0, so we can log what happened
 set -u +e
 
-$(dirname "$0")/maven_unjar $args
+unjar_out=$($(dirname "$0")/maven_unjar $args 2>&1)
 unjar_rc=$?
 
 if [ "${unjar_rc}" = "0" ] || [ -z "${pom:-}" ]; then
@@ -51,6 +51,7 @@ case ${version} in
   *-SNAPSHOT )
     ;;
   * )
+    >&2 echo ${unjar_out}
     exit ${unjar_rc}
     ;;
 esac

--- a/build-bin/maven/maven_release
+++ b/build-bin/maven/maven_release
@@ -40,4 +40,4 @@ if [ "$commit_local_release_branch" != "$commit_remote_release_branch" ]; then
 fi
 
 # Prepare and push release commits and the version tag (N.N.N), which triggers deployment.
-./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Darguments=-DskipTests release:prepare
+./mvnw --batch-mode -nsu -DreleaseVersion=${release_version} -Denforcer.fail=false -Darguments="-DskipTests -Denforcer.fail=false" release:prepare

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -26,7 +26,7 @@ set -eu
 # the artifact you are looking for.
 #
 # Ex.
-# !./module/target/zipkin-module-stackdriver-*-module.jar
+# !./module/target/zipkin-module-*-module.jar
 
 group_id=${1?group_id is required}
 artifact_id=${2?artifact_id is required}
@@ -60,7 +60,8 @@ elif [ -n "${MAVEN_PROJECT_BASEDIR:-}" ]; then
 fi
 
 if ! test -f ${artifact_id}.jar && [ ${is_release} = "true" ]; then
-  mvn_get="mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
+  mvn_get="mvn -q --batch-mode -Denforcer.fail=false \
+  org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
   -Dtransitive=false -DgroupId=${group_id} -DartifactId=${artifact_id} -Dversion=${version}"
 
   if [ -n "${classifier}" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -497,12 +497,12 @@
   </build>
 
   <profiles>
-    <!-- -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central -->
+    <!-- -DskipTests ensures benchmarks don't end up in javadocs or in Maven Central -->
     <profile>
       <id>include-benchmarks</id>
       <activation>
         <property>
-          <name>!skipBenchmarks</name>
+          <name>!skipTests</name>
         </property>
       </activation>
       <modules>


### PR DESCRIPTION
When there was no prior build, this would have not worked

```bash
build-bin/docker/docker_build openzipkin/zipkin-gcp:test
```