### PR TITLE
Update Zipkin to address CVE-2021-44228

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 The OpenZipkin Authors
+# Copyright 2016-2021 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.23.2
+ARG zipkin_version=2.23.4
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.23.4
+ARG zipkin_version=2.23.15
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2021 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.23.2</zipkin.version>
+    <zipkin.version>2.23.4</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
     <spring-boot.version>2.4.1</spring-boot.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.23.4</zipkin.version>
+    <zipkin.version>2.23.15</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
     <spring-boot.version>2.4.1</spring-boot.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->


### PR DESCRIPTION
Updated the Zipkin version to address [#Issue-194](https://github.com/openzipkin/zipkin-gcp/issues/194)