### PR TITLE
Prepares for release by updating to Brave 5.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,20 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <main.basedir>${project.basedir}</main.basedir>
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
 
-    <!-- groupId overrinds allow testing feature branches with jitpack -->
+    <!-- default bytecode version for src/main -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- We don't use animal-sniffer anymore as release obviates it.
+         See https://github.com/mojohaus/animal-sniffer/issues/62 -->
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Tests use the floor Java version (used in release) -->
+    <maven.compiler.testSource>11</maven.compiler.testSource>
+    <maven.compiler.testTarget>11</maven.compiler.testTarget>
+    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+
+    <!-- groupId overrides allow testing feature branches with jitpack -->
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
@@ -73,7 +83,7 @@
     <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
     <!--    <brave.version>master-SNAPSHOT</brave.version>-->
     <brave.groupId>io.zipkin.brave</brave.groupId>
-    <brave.version>5.17.1</brave.version>
+    <brave.version>5.18.1</brave.version>
 
     <!-- from armeria-grpc -->
     <grpc.version>1.58.0</grpc.version>
@@ -92,22 +102,26 @@
     <google-cloud-pubsub.version>1.125.13</google-cloud-pubsub.version>
     <grpc-google-cloud-pubsub-v1.version>1.107.13</grpc-google-cloud-pubsub-v1.version>
 
-    <assertj.version>3.24.2</assertj.version>
+    <assertj.version>3.25.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <mockito.version>5.8.0</mockito.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.23.0</errorprone.version>
+    <errorprone.version>2.24.1</errorprone.version>
+    <auto-value.version>1.10.4</auto-value.version>
 
     <license.skip>${skipTests}</license.skip>
 
-    <animal-sniffer-maven-plugin.version>1.23</animal-sniffer-maven-plugin.version>
+    <maven-surefire-plugin.argLine />
+    <maven-failsafe-plugin.argLine />
+
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -115,12 +129,12 @@
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 
@@ -213,13 +227,6 @@
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
               <DynamicDependency>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>${main.signature.artifact}</artifactId>
-                <version>1.0</version>
-                <type>signature</type>
-                <repositoryType>MAIN</repositoryType>
-              </DynamicDependency>
-              <DynamicDependency>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin-git</artifactId>
                 <version>${license-maven-plugin.version}</version>
@@ -298,10 +305,7 @@
         <version>${maven-compiler-plugin.version}</version>
         <inherited>true</inherited>
         <configuration>
-          <source>${main.java.version}</source>
-          <target>${main.java.version}</target>
           <fork>true</fork>
-          <release>8</release>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
@@ -312,9 +316,6 @@
         <configuration>
           <!-- Ensures root cause ends up in the console -->
           <trimStackTrace>false</trimStackTrace>
-          <!-- TODO: remove when assertj releases a new version, and includes updated bytebuddy.
-               https://github.com/mockito/mockito/issues/3119#issuecomment-1732179039 -->
-          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
         <dependencies>
           <!-- needed for surefire.
@@ -356,33 +357,7 @@
           <useModulePath>false</useModulePath>
           <!-- Ensures root cause ends up in the console -->
           <trimStackTrace>false</trimStackTrace>
-          <!-- TODO: remove when assertj releases a new version, and includes updated bytebuddy.
-                https://github.com/mockito/mockito/issues/3119#issuecomment-1732179039 -->
-          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
-      </plugin>
-
-      <!-- Ensure no Java 9+ api usage -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <checkTestClasses>false</checkTestClasses>
-          <skip>${skipTests}</skip>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>${main.signature.artifact}</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -524,8 +499,6 @@
             <version>${maven-compiler-plugin.version}</version>
             <inherited>true</inherited>
             <configuration>
-              <source>${main.java.version}</source>
-              <target>${main.java.version}</target>
               <fork>true</fork>
               <showWarnings>true</showWarnings>
             </configuration>

--- a/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/StackdriverTracePropagation.java
@@ -57,6 +57,8 @@ public class StackdriverTracePropagation implements Propagation<String> {
      * @deprecated end users and instrumentation should never call this, and instead use
      * {@link #get()}. This only remains to avoid rev-lock upgrading to Brave 6.
      */
+    // This only exists for spring-cloud-sleuth, which is no longer being released. It hasn't and
+    // might not upgrade to Brave 5.18 which implements the same way.
     @Deprecated public <K> Propagation<K> create(KeyFactory<K> unused) {
       throw new UnsupportedOperationException("As of Brave 5.12, call PropagationFactory.get()");
     }

--- a/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/zipkin2/propagation/stackdriver/StackdriverTracePropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,9 +37,14 @@ public final class StackdriverTracePropagation<K> implements Propagation<K> {
           return new StackdriverTracePropagation<>(DELEGATE.get(), KeyFactory.STRING);
         }
 
-        @Override
-        public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-          return new StackdriverTracePropagation<>(DELEGATE.create(keyFactory), keyFactory);
+        /**
+         * @deprecated end users and instrumentation should never call this, and instead use
+         * {@link #get()}. This only remains to avoid rev-lock upgrading to Brave 6.
+         */
+        // This only exists for spring-cloud-sleuth, which is no longer being released. It hasn't and
+        // might not upgrade to Brave 5.18 which implements the same way.
+        @Deprecated public <K> Propagation<K> create(KeyFactory<K> unused) {
+          throw new UnsupportedOperationException("As of Brave 5.12, call PropagationFactory.get()");
         }
 
         @Override


### PR DESCRIPTION
Note after we release, we should bump major when updating to zipkin-reporter 3.0.1