### PR TITLE
Updates to Zipkin 3, Spring Boot 3 and JRE 17

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,13 +24,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS and last that can compile the 1.6 release profile.
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-11-maven-
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Create Release
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       # Don't attempt to cache Docker. Sensitive information can be stolen
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '17'  # earliest LTS supported by Spring Boot 3
       - name: Cache local Maven repository
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-11-maven-
+          key: ${{ runner.os }}-jdk-17-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Build JavaDoc
         run: ./mvnw clean javadoc:aggregate -Prelease
 
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are operating system specific
       matrix:  # use latest available versions and be consistent on all workflows!
         include:
-          - java_version: 11  # Last that can compile zipkin core to 1.6 for zipkin-reporter
+          - java_version: 17  # earliest LTS supported by Spring Boot 3
             maven_args: -Prelease -Dgpg.skip -Dmaven.javadoc.skip=true
           - java_version: 21  # Most recent LTS
     steps:
@@ -69,4 +69,4 @@ jobs:
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test
-        run: build-bin/configure_test && build-bin/test
+        run: build-bin/configure_test && build-bin/test ${{ matrix.maven_args }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.zipkin.gcp/zipkin-module-gcp.svg)](https://search.maven.org/search?q=g:io.zipkin.gcp%20AND%20a:zipkin-module-gcp)
 
 # zipkin-gcp
-Shared libraries that provide Zipkin integration with the Google Cloud Platform. Requires JRE 11 or later.
+Shared libraries that provide Zipkin integration with the Google Cloud Platform. Requires JRE 17 or later.
 
 # Usage
 These components integrate traced applications and servers through Google Cloud services
@@ -71,7 +71,7 @@ $ STORAGE_TYPE=stackdriver STACKDRIVER_PROJECT_ID=zipkin-demo \
     -Dloader.path='gcp.jar,gcp.jar!/lib' \
     -Dspring.profiles.active=gcp \
     -cp zipkin.jar \
-    org.springframework.boot.loader.PropertiesLauncher
+    org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 ## Example integrating Stackdriver Storage

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -30,6 +30,10 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <jmh.version>1.27</jmh.version>
+
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/collector-pubsub/pom.xml
+++ b/collector-pubsub/pom.xml
@@ -26,6 +26,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=2.27.0
+ARG zipkin_version=3.0.0
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/module/README.md
+++ b/module/README.md
@@ -16,7 +16,7 @@ and exposes configuration options through environment variables.
 
 ## Quick start
 
-JRE 11+ is required to run Zipkin server.
+JRE 17+ is required to run Zipkin server.
 
 Fetch the latest released
 [executable jar for Zipkin server](https://search.maven.org/remote_content?g=io.zipkin&a=zipkin-server&v=LATEST&c=exec)
@@ -34,7 +34,7 @@ $ STORAGE_TYPE=stackdriver STACKDRIVER_PROJECT_ID=zipkin-demo \
     -Dloader.path='gcp.jar,gcp.jar!/lib' \
     -Dspring.profiles.active=gcp \
     -cp zipkin.jar \
-    org.springframework.boot.loader.PropertiesLauncher
+    org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 After executing these steps, applications can send spans
@@ -52,12 +52,12 @@ for users that prefer a file based approach.
 
 #### Environment Variables
 
-|Environment Variable           | Value            |
-|-------------------------------|------------------|
-|GOOGLE_APPLICATION_CREDENTIALS | Optional. [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials). Not managed by spring boot. |
-|STACKDRIVER_PROJECT_ID         | GCP projectId. Optional on GCE. Required on all other platforms. If not provided on GCE, it will default to the projectId associated with the GCE resource. |
-|STACKDRIVER_API_HOST           | host:port combination of the gRPC endpoint. Default: cloudtrace.googleapis.com:443 |
-|STACKDRIVER_HTTP_LOGGING       | When set, controls the volume of HTTP logging of the Stackdriver Trace Api. Options are BASIC and HEADERS |
+| Environment Variable           | Value                                                                                                                                                             |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| GOOGLE_APPLICATION_CREDENTIALS | Optional. [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials). Not managed by spring boot. |
+| STACKDRIVER_PROJECT_ID         | GCP projectId. Optional on GCE. Required on all other platforms. If not provided on GCE, it will default to the projectId associated with the GCE resource.       |
+| STACKDRIVER_API_HOST           | host:port combination of the gRPC endpoint. Default: cloudtrace.googleapis.com:443                                                                                |
+| STACKDRIVER_HTTP_LOGGING       | When set, controls the volume of HTTP logging of the Stackdriver Trace Api. Options are BASIC and HEADERS                                                         |
 
 ### Running
 
@@ -67,7 +67,7 @@ $ STORAGE_TYPE=stackdriver STACKDRIVER_PROJECT_ID=zipkin-demo STACKDRIVER_HTTP_L
     -Dloader.path='gcp.jar,gcp.jar!/lib' \
     -Dspring.profiles.active=gcp \
     -cp zipkin.jar \
-    org.springframework.boot.loader.PropertiesLauncher
+    org.springframework.boot.loader.launch.PropertiesLauncher
 ```
 
 ### Testing

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -27,6 +27,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -68,6 +73,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
       <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>
@@ -159,7 +169,7 @@
           <classifier>module</classifier>
           <!-- https://github.com/spring-projects/spring-boot/issues/3426 transitive exclude doesn't work -->
           <excludeGroupIds>
-            ${zipkin.groupId},org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils,${armeria.groupId},javax.inject,com.fasterxml.jackson.datatype
+            ${zipkin.groupId},org.springframework.boot,org.springframework,com.fasterxml.jackson.core,com.google.auto.value,org.reactivestreams,com.google.code.findbugs,javax.annotation,org.slf4j,io.netty,io.micrometer,org.hdrhistogram,org.latencyutils,${armeria.groupId},javax.inject,com.fasterxml.jackson.datatype,com.aayushatharva.brotli4j,commons-logging
           </excludeGroupIds>
           <excludes>
             <!-- zipkin-server depends on armeria and its grpc protocol-->

--- a/module/src/test/java/zipkin2/storage/stackdriver/ITZipkinStackdriverStorage.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/ITZipkinStackdriverStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -121,8 +121,8 @@ public class ITZipkinStackdriverStorage {
         .atMost(10, TimeUnit.SECONDS)
         .pollInterval(1, TimeUnit.SECONDS)
         .ignoreExceptionsMatching(e ->
-            e instanceof StatusRuntimeException &&
-                ((StatusRuntimeException) e).getStatus().getCode() == Status.Code.NOT_FOUND
+            e instanceof StatusRuntimeException sre &&
+                sre.getStatus().getCode() == Status.Code.NOT_FOUND
         )
         .until(() -> traceServiceGrpcV1.getTrace(GetTraceRequest.newBuilder()
             .setProjectId(projectId)

--- a/module/src/test/java/zipkin2/storage/stackdriver/StackdriverMockServer.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/StackdriverMockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -66,7 +66,7 @@ public class StackdriverMockServer extends ServerExtension {
   }
 
   public String grpcURI() {
-    return String.format("%s:%s", "localhost", getPort());
+    return "%s:%s".formatted("localhost", getPort());
   }
 
   public Set<String> spanIds() {

--- a/pom.xml
+++ b/pom.xml
@@ -66,20 +66,21 @@
     <maven.compiler.release>8</maven.compiler.release>
 
     <!-- Tests use the floor Java version (used in release) -->
-    <maven.compiler.testSource>11</maven.compiler.testSource>
-    <maven.compiler.testTarget>11</maven.compiler.testTarget>
-    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+    <maven.compiler.testSource>17</maven.compiler.testSource>
+    <maven.compiler.testTarget>17</maven.compiler.testTarget>
+    <maven.compiler.testRelease>17</maven.compiler.testRelease>
 
     <!-- groupId overrides allow testing feature branches with jitpack -->
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>2.27.1</zipkin.version>
-    <zipkin-reporter.version>3.1.0</zipkin-reporter.version>
-    <spring-boot.version>2.7.18</spring-boot.version>
+    <zipkin.version>3.0.0-SNAPSHOT</zipkin.version>
+    <zipkin-reporter.version>3.1.1</zipkin-reporter.version>
+    <spring-boot.version>3.2.1</spring-boot.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
     <armeria.version>1.26.4</armeria.version>
+    <log4j.version>2.21.1</log4j.version>
 
     <!-- This allows you to test feature branches with jitpack -->
     <!--    <brave.groupId>com.github.openzipkin.brave</brave.groupId>-->
@@ -175,6 +176,21 @@
     </developer>
   </developers>
 
+  <!-- TODO: delete -->
+  <repositories>
+    <repository>
+      <id>sonatype.snapshots</id>
+      <name>Sonatype Snapshot Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -205,9 +221,21 @@
     </dependency>
     <!-- Main code uses jul and tests log with log4j -->
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -377,7 +405,7 @@
                 <requireJavaVersion>
                   <!-- Change this to control LTS JDK versions allowed to build
                        the project. Keep in sync with .github/workflows -->
-                  <version>[11,12),[17,18),[21,22)</version>
+                  <version>[17,18),[21,22)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -490,10 +518,10 @@
 
 
     <profile>
-      <id>error-prone-11+</id>
+      <id>error-prone-17+</id>
       <activation>
         <!-- Only LTS versions -->
-        <jdk>[11,12),[17,18),[21,22)</jdk>
+        <jdk>[17,18),[21,22)</jdk>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>3.0.0-SNAPSHOT</zipkin.version>
+    <zipkin.version>3.0.0</zipkin.version>
     <zipkin-reporter.version>3.1.1</zipkin-reporter.version>
     <spring-boot.version>3.2.1</spring-boot.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
@@ -175,21 +175,6 @@
       <url>https://gitter.im/openzipkin/zipkin</url>
     </developer>
   </developers>
-
-  <!-- TODO: delete -->
-  <repositories>
-    <repository>
-      <id>sonatype.snapshots</id>
-      <name>Sonatype Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
   <dependencyManagement>
     <dependencies>

--- a/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/ITStackdriverSender.java
+++ b/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/ITStackdriverSender.java
@@ -129,8 +129,8 @@ public class ITStackdriverSender {
         .atMost(10, TimeUnit.SECONDS)
         .pollInterval(1, TimeUnit.SECONDS)
         .ignoreExceptionsMatching(e ->
-            e instanceof StatusRuntimeException &&
-                ((StatusRuntimeException) e).getStatus().getCode() == Status.Code.NOT_FOUND
+            e instanceof StatusRuntimeException sre &&
+                sre.getStatus().getCode() == Status.Code.NOT_FOUND
         )
         .until(() -> traceServiceGrpcV1.getTrace(GetTraceRequest.newBuilder()
             .setProjectId(projectId)
@@ -165,8 +165,8 @@ public class ITStackdriverSender {
         .atMost(10, TimeUnit.SECONDS)
         .pollInterval(1, TimeUnit.SECONDS)
         .ignoreExceptionsMatching(e ->
-            e instanceof StatusRuntimeException &&
-                ((StatusRuntimeException) e).getStatus().getCode() == Status.Code.NOT_FOUND
+            e instanceof StatusRuntimeException sre &&
+                sre.getStatus().getCode() == Status.Code.NOT_FOUND
         )
         .until(() -> traceServiceGrpcV1.getTrace(GetTraceRequest.newBuilder()
             .setProjectId(projectId)

--- a/storage-stackdriver/pom.xml
+++ b/storage-stackdriver/pom.xml
@@ -27,6 +27,11 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Only used in zipkin-server, which has floor JRE 17 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This updates server modules to Zipkin 3, Spring Boot 3 and JRE 17. It leaves the client side modules at Java 8.

In order to compile the server module, we can no longer compile with JDK 11.

See https://github.com/openzipkin/zipkin/pull/3684