### PR TITLE
removes invalid openssl check and bumps deps

### DIFF
--- a/build-bin/docker-compose-zipkin-gcp.yml
+++ b/build-bin/docker-compose-zipkin-gcp.yml
@@ -3,14 +3,14 @@ volumes:
   gcp-service-account:
 services:
   extract-service-account:
-    image: ghcr.io/openzipkin/alpine:3.19.0
+    image: ghcr.io/openzipkin/alpine:3.19.1
     volumes:
       - gcp-service-account:/credentials:rw
     command: -c 'echo $GOOGLE_APPLICATION_CREDENTIALS_BASE64 | base64 -d > /credentials/service-account-key.json'
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS_BASE64
   show-service-account:
-    image: ghcr.io/openzipkin/alpine:3.19.0
+    image: ghcr.io/openzipkin/alpine:3.19.1
     volumes:
       - gcp-service-account:/credentials:ro
     # Show that the file exists as a sanity check in logs.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # zipkin version should match zipkin.version in /pom.xml
-ARG zipkin_version=3.0.5
+ARG zipkin_version=3.0.6
 
 # java_version is used during the installation process to build or download the module jar.
 #

--- a/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/AttributesExtractor.java
+++ b/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/AttributesExtractor.java
@@ -16,14 +16,12 @@ package zipkin2.reporter.stackdriver.brave;
 import brave.Span;
 import brave.Tag;
 import brave.handler.MutableSpan;
-import com.google.common.net.HostAndPort;
 import com.google.common.net.InetAddresses;
 import com.google.devtools.cloudtrace.v2.AttributeValue;
 import com.google.devtools.cloudtrace.v2.Span.Attributes;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.Map;
 
 import static zipkin2.reporter.stackdriver.brave.SpanUtil.toTruncatableString;

--- a/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/SpanTranslatorTest.java
+++ b/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/SpanTranslatorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.reporter.stackdriver.brave.AttributesExtractor.toAttributeValue;
-import static zipkin2.reporter.stackdriver.brave.SpanTranslator.createTimestamp;
 import static zipkin2.reporter.stackdriver.brave.SpanUtil.toTruncatableString;
 import static zipkin2.reporter.stackdriver.brave.TestObjects.clientSpan;
 

--- a/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageModule.java
+++ b/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageModule.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
-import io.netty.handler.ssl.OpenSsl;
 import java.io.IOException;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -94,11 +93,6 @@ public class ZipkinStackdriverStorageModule {
       ClientFactory clientFactory,
       ZipkinStackdriverStorageProperties properties,
       Credentials credentials) {
-    if (!OpenSsl.isAvailable()) {
-      throw new IllegalStateException(
-          "OpenSsl is required. This usually requires netty-tcnative-boringssl-static");
-    }
-
     ClientOptionsBuilder options = ClientOptions.builder();
 
     HttpLogging httpLogging = properties.getHttpLogging();

--- a/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageIntegrationTest.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,12 +30,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,12 @@
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>
     <!-- when updating, update docker/Dockerfile and storage/src/test/java/zipkin2/storage/kafka/IT* -->
-    <zipkin.version>3.0.5</zipkin.version>
-    <zipkin-reporter.version>3.2.1</zipkin-reporter.version>
+    <zipkin.version>3.0.6</zipkin.version>
+    <zipkin-reporter.version>3.3.0</zipkin-reporter.version>
     <spring-boot.version>3.2.2</spring-boot.version>
     <!-- armeria.groupId allows you to test feature branches with jitpack -->
     <armeria.groupId>com.linecorp.armeria</armeria.groupId>
-    <armeria.version>1.26.4</armeria.version>
+    <armeria.version>1.27.1</armeria.version>
     <log4j.version>2.21.1</log4j.version>
 
     <!-- This allows you to test feature branches with jitpack -->
@@ -89,29 +89,29 @@
     <brave.version>6.0.0</brave.version>
 
     <!-- from armeria-grpc or grpc-google-cloud-trace-v1 whichever is higher -->
-    <grpc.version>1.60.0</grpc.version>
+    <grpc.version>1.61.1</grpc.version>
     <!-- from grpc-protobuf -->
-    <protobuf.version>3.24.0</protobuf.version>
-    <guava.version>32.0.1-android</guava.version>
+    <protobuf.version>3.25.1</protobuf.version>
+    <guava.version>32.1.3</guava.version>
 
     <!-- stackdriver deps -->
-    <google-auth-library-oauth2-http.version>1.22.0</google-auth-library-oauth2-http.version>
-    <proto-google-common-protos.version>2.31.0</proto-google-common-protos.version>
+    <google-auth-library-oauth2-http.version>1.23.0</google-auth-library-oauth2-http.version>
+    <proto-google-common-protos.version>2.34.0</proto-google-common-protos.version>
     <!-- only used for stackdriver protos, we could possibly obviate this if a problem -->
-    <grpc-google-cloud-trace.version>2.34.0</grpc-google-cloud-trace.version>
+    <grpc-google-cloud-trace.version>2.35.0</grpc-google-cloud-trace.version>
 
     <!-- pubsub deps -->
-    <google-cloud-pubsub.version>1.126.0</google-cloud-pubsub.version>
-    <grpc-google-cloud-pubsub-v1.version>1.108.0</grpc-google-cloud-pubsub-v1.version>
+    <google-cloud-pubsub.version>1.126.6</google-cloud-pubsub.version>
+    <grpc-google-cloud-pubsub-v1.version>1.108.6</grpc-google-cloud-pubsub-v1.version>
 
-    <assertj.version>3.25.1</assertj.version>
+    <assertj.version>3.25.3</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
-    <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <mockito.version>5.9.0</mockito.version>
+    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <mockito.version>5.10.0</mockito.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.24.1</errorprone.version>
+    <errorprone.version>2.25.0</errorprone.version>
     <auto-value.version>1.10.4</auto-value.version>
 
     <license.skip>${skipTests}</license.skip>

--- a/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package brave.propagation.stackdriver;
 
 import brave.propagation.B3Propagation;
-import brave.propagation.Propagation;
 import brave.propagation.TraceContextOrSamplingFlags;
 import org.junit.jupiter.api.Test;
 

--- a/sender-pubsub/src/test/java/zipkin2/reporter/pubsub/PubSubSenderTest.java
+++ b/sender-pubsub/src/test/java/zipkin2/reporter/pubsub/PubSubSenderTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.stub.GrpcPublisherStub;
 import com.google.cloud.pubsub.v1.stub.PublisherStub;
 import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
-import com.google.pubsub.v1.GetTopicRequest;
 import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.PublisherGrpc;

--- a/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/AsyncReporterStackdriverSenderTest.java
+++ b/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/AsyncReporterStackdriverSenderTest.java
@@ -41,7 +41,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package zipkin2.translation.stackdriver;
 
 import com.google.protobuf.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;


### PR DESCRIPTION
@provegard mentioned on gitter that we are getting an openssl error. I think the check is no longer valid after we switched to latest JRE + spring boot 3, as when I remove the check, the docker image (alpine JRE 21) works fine. So, I'm removing the check and in worst case, if someone has a misconfiguration, they get a late error in /health, but we don't get a false report for everybody else.


Traces created with https://github.com/openzipkin/brave-example/tree/master/armeria and self-tracing too.
I ran the locally build docker image like so, configured with `Trace Agent` role

```bash
$ docker run --rm -p 9411:9411 --name zipkin-gcp -e SELF_TRACING_ENABLED=true  -e STORAGE_TYPE=stackdriver   -e GOOGLE_APPLICATION_CREDENTIALS=/zipkin/.gcp/credentials.json   -e STACKDRIVER_PROJECT_ID=adrian-test-414623    -v $HOME/.gcp:/zipkin/.gcp:ro   openzipkin/zipkin-gcp:test
```

![Screenshot 2024-02-18 at 08 15 24](https://github.com/openzipkin/zipkin-gcp/assets/64215/37521038-7275-4656-b819-396c7a0dbf74)
