### PR TITLE
license: removes copyright year and uses SPDX ID

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,17 +17,8 @@ If you are adding a new file it should have a header like below. This
 can be automatically added by running `./mvnw com.mycila:license-maven-plugin:format`.
 
 ```
-/**
- * Copyright 2019 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
  ```

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,7 +18,6 @@ jobs:
           # Prevent use of implicit GitHub Actions read-only GITHUB_TOKEN
           # because maven-release-plugin pushes commits to master.
           token: ${{ secrets.GH_TOKEN }}
-          fetch-depth: 1  # license check is skipped, so we don't need history
       - name: Setup java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,6 @@ jobs:
           # Prevent use of implicit GitHub Actions read-only GITHUB_TOKEN
           # because javadoc_to_gh_pages pushes commits to the gh-pages branch.
           token: ${{ secrets.GH_TOKEN }}
-          # allow build-bin/javadoc_to_gh_pages to get the full history
-          fetch-depth: 0
       - name: Setup java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1  # only needed to get the sha label
       # Don't attempt to cache Docker. Sensitive information can be stolen
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full git history for license check
       - name: Setup java
         uses: actions/setup-java@v4
         with:

--- a/.settings.xml
+++ b/.settings.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,23 +45,6 @@ Here's an example of a snapshot deploy with specified credentials.
 $ export GPG_TTY=$(tty) && GPG_PASSPHRASE=whackamole SONATYPE_USER=adrianmole SONATYPE_PASSWORD=ed6f20bde9123bbb2312b221 build-bin/build-bin/maven/maven_deploy
 ```
 
-## First release of the year
-
-The license plugin verifies license headers of files include a copyright notice indicating the years a file was affected.
-This information is taken from git history. There's a once-a-year problem with files that include version numbers (pom.xml).
-When a release tag is made, it increments version numbers, then commits them to git. On the first release of the year,
-further commands will fail due to the version increments invalidating the copyright statement. The way to sort this out is
-the following:
-
-Before you do the first release of the year, move the SNAPSHOT version back and forth from whatever the current is.
-In-between, re-apply the licenses.
-```bash
-$ ./mvnw versions:set -DnewVersion=1.3.3-SNAPSHOT -DgenerateBackupPoms=false
-$ ./mvnw com.mycila:license-maven-plugin:format
-$ ./mvnw versions:set -DnewVersion=1.3.2-SNAPSHOT -DgenerateBackupPoms=false
-$ git commit -am"Adjusts copyright headers for this year"
-```
-
 ## Manually releasing
 
 If for some reason, you lost access to CI or otherwise cannot get automation to work, bear in mind

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/benchmarks/src/main/java/zipkin2/reporter/stackdriver/TracesParserBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/stackdriver/TracesParserBenchmarks.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/benchmarks/src/main/java/zipkin2/reporter/stackdriver/brave/StackdriverV2EncoderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/stackdriver/brave/StackdriverV2EncoderBenchmarks.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/benchmarks/src/main/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoderBenchmarks.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.zipkin;
 

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -139,8 +139,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full git history for license check
       - name: Test
         run: |
           build-bin/configure_test
@@ -186,8 +184,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1  # only needed to get the sha label
       - name: Deploy
         env:
           GH_USER: ${{ secrets.GH_USER }}

--- a/build-bin/docker/configure_docker
+++ b/build-bin/docker/configure_docker
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Defends against build outages caused by Docker Hub (docker.io) pull rate limits.

--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Ensures Docker is logged in and it can build multi-architecture.

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script gets a normalized name for the architecture as used in Docker. This will be a subset

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2024 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This builds common docker arguments used by docker_build and docker_push.

--- a/build-bin/docker/docker_block_on_health
+++ b/build-bin/docker/docker_block_on_health
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Blocks until a named docker container with a valid HEALTHCHECK instruction is healthy or not:

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script pushes images to GitHub Container Registry (ghcr.io).

--- a/build-bin/docker/docker_test_image
+++ b/build-bin/docker/docker_test_image
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # Tests a an image by awaiting its HEALTHCHECK.

--- a/build-bin/git/login_git
+++ b/build-bin/git/login_git
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/git/version_from_trigger_tag
+++ b/build-bin/git/version_from_trigger_tag
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script echos a `MAJOR.MINOR.PATCH` version tag based on..

--- a/build-bin/gpg/configure_gpg
+++ b/build-bin/gpg/configure_gpg
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script prepares GPG, needed to sign jars for Sonatype deployment during `maven_deploy`

--- a/build-bin/maven/maven_build
+++ b/build-bin/maven/maven_build
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/maven/maven_build_or_unjar
+++ b/build-bin/maven/maven_build_or_unjar
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/maven/maven_deploy
+++ b/build-bin/maven/maven_deploy
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/maven/maven_go_offline
+++ b/build-bin/maven/maven_go_offline
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This is a go-offline that properly works with multi-module builds

--- a/build-bin/maven/maven_opts
+++ b/build-bin/maven/maven_opts
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script checks each variable value, so it isn't important to fail on unbound (set -u)

--- a/build-bin/maven/maven_release
+++ b/build-bin/maven/maven_release
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -ue

--- a/build-bin/maven/maven_unjar
+++ b/build-bin/maven/maven_unjar
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2016-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # This script gets one jar from Maven, most typically an exec or module jar, extracting its contents

--- a/collector-pubsub/pom.xml
+++ b/collector-pubsub/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/collector-pubsub/src/main/java/zipkin2/collector/pubsub/PubSubCollector.java
+++ b/collector-pubsub/src/main/java/zipkin2/collector/pubsub/PubSubCollector.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SpanCallback.java
+++ b/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SpanCallback.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SpanMessageReceiver.java
+++ b/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SpanMessageReceiver.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SubscriberSettings.java
+++ b/collector-pubsub/src/main/java/zipkin2/collector/pubsub/SubscriberSettings.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/test/java/zipkin2/collector/pubsub/PubSubCollectorTest.java
+++ b/collector-pubsub/src/test/java/zipkin2/collector/pubsub/PubSubCollectorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/test/java/zipkin2/collector/pubsub/QueueBasedSubscriberImpl.java
+++ b/collector-pubsub/src/test/java/zipkin2/collector/pubsub/QueueBasedSubscriberImpl.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/collector-pubsub/src/test/java/zipkin2/collector/pubsub/StreamingPullStreamObserver.java
+++ b/collector-pubsub/src/test/java/zipkin2/collector/pubsub/StreamingPullStreamObserver.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.collector.pubsub;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,6 @@
 #
-# Copyright 2016-2024 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # zipkin version should match zipkin.version in /pom.xml

--- a/encoder-stackdriver-brave/pom.xml
+++ b/encoder-stackdriver-brave/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/AttributesExtractor.java
+++ b/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/AttributesExtractor.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/SpanTranslator.java
+++ b/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/SpanTranslator.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/SpanUtil.java
+++ b/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/SpanUtil.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/StackdriverV2Encoder.java
+++ b/encoder-stackdriver-brave/src/main/java/zipkin2/reporter/stackdriver/brave/StackdriverV2Encoder.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/AttributesExtractorTest.java
+++ b/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/AttributesExtractorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/SpanTranslatorTest.java
+++ b/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/SpanTranslatorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/StackdriverV2EncoderTest.java
+++ b/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/StackdriverV2EncoderTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/TestObjects.java
+++ b/encoder-stackdriver-brave/src/test/java/zipkin2/reporter/stackdriver/brave/TestObjects.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.brave;
 

--- a/encoder-stackdriver-zipkin/pom.xml
+++ b/encoder-stackdriver-zipkin/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/encoder-stackdriver-zipkin/src/main/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoder.java
+++ b/encoder-stackdriver-zipkin/src/main/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoder.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.zipkin;
 

--- a/encoder-stackdriver-zipkin/src/test/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoderTest.java
+++ b/encoder-stackdriver-zipkin/src/test/java/zipkin2/reporter/stackdriver/zipkin/StackdriverEncoderTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver.zipkin;
 

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/module/src/main/java/zipkin/module/storage/stackdriver/CredentialsDecoratingClient.java
+++ b/module/src/main/java/zipkin/module/storage/stackdriver/CredentialsDecoratingClient.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin.module.storage.stackdriver;
 

--- a/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageModule.java
+++ b/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageModule.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin.module.storage.stackdriver;
 

--- a/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageProperties.java
+++ b/module/src/main/java/zipkin/module/storage/stackdriver/ZipkinStackdriverStorageProperties.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin.module.storage.stackdriver;
 

--- a/module/src/test/java/zipkin2/storage/stackdriver/ITZipkinStackdriverStorage.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/ITZipkinStackdriverStorage.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/module/src/test/java/zipkin2/storage/stackdriver/StackdriverMockServer.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/StackdriverMockServer.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageIntegrationTest.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageIntegrationTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageModuleTest.java
+++ b/module/src/test/java/zipkin2/storage/stackdriver/ZipkinStackdriverStorageModuleTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/propagation-stackdriver/pom.xml
+++ b/propagation-stackdriver/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/StackdriverTracePropagation.java
+++ b/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/StackdriverTracePropagation.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package brave.propagation.stackdriver;
 

--- a/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/XCloudTraceContextExtractor.java
+++ b/propagation-stackdriver/src/main/java/brave/propagation/stackdriver/XCloudTraceContextExtractor.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package brave.propagation.stackdriver;
 

--- a/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/StackdriverTracePropagationTest.java
+++ b/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/StackdriverTracePropagationTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package brave.propagation.stackdriver;
 

--- a/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/XCloudTraceContextExtractorTest.java
+++ b/propagation-stackdriver/src/test/java/brave/propagation/stackdriver/XCloudTraceContextExtractorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package brave.propagation.stackdriver;
 

--- a/sender-pubsub/pom.xml
+++ b/sender-pubsub/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sender-pubsub/src/main/java/zipkin2/reporter/pubsub/PubSubSender.java
+++ b/sender-pubsub/src/main/java/zipkin2/reporter/pubsub/PubSubSender.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.pubsub;
 

--- a/sender-pubsub/src/main/java/zipkin2/reporter/pubsub/PubSubSenderInitializationException.java
+++ b/sender-pubsub/src/main/java/zipkin2/reporter/pubsub/PubSubSenderInitializationException.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.pubsub;
 

--- a/sender-pubsub/src/test/java/zipkin2/reporter/pubsub/PubSubSenderTest.java
+++ b/sender-pubsub/src/test/java/zipkin2/reporter/pubsub/PubSubSenderTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.pubsub;
 

--- a/sender-stackdriver/pom.xml
+++ b/sender-stackdriver/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/AwaitableUnaryClientCallListener.java
+++ b/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/AwaitableUnaryClientCallListener.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java
+++ b/sender-stackdriver/src/main/java/zipkin2/reporter/stackdriver/StackdriverSender.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/AsyncReporterStackdriverSenderTest.java
+++ b/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/AsyncReporterStackdriverSenderTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/ITStackdriverSender.java
+++ b/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/ITStackdriverSender.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/StackdriverSenderTest.java
+++ b/sender-stackdriver/src/test/java/zipkin2/reporter/stackdriver/StackdriverSenderTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.reporter.stackdriver;
 

--- a/src/etc/header.txt
+++ b/src/etc/header.txt
@@ -1,11 +1,2 @@
-Copyright ${license.git.copyrightYears} The OpenZipkin Authors
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License
-is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-or implied. See the License for the specific language governing permissions and limitations under
-the License.
+Copyright The OpenZipkin Authors
+SPDX-License-Identifier: Apache-2.0

--- a/storage-stackdriver/pom.xml
+++ b/storage-stackdriver/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/storage-stackdriver/src/main/java/zipkin2/storage/stackdriver/StackdriverSpanConsumer.java
+++ b/storage-stackdriver/src/main/java/zipkin2/storage/stackdriver/StackdriverSpanConsumer.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/storage-stackdriver/src/main/java/zipkin2/storage/stackdriver/StackdriverStorage.java
+++ b/storage-stackdriver/src/main/java/zipkin2/storage/stackdriver/StackdriverStorage.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/storage-stackdriver/src/test/java/zipkin2/storage/stackdriver/StackdriverSpanConsumerTest.java
+++ b/storage-stackdriver/src/test/java/zipkin2/storage/stackdriver/StackdriverSpanConsumerTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.storage.stackdriver;
 

--- a/translation-stackdriver/pom.xml
+++ b/translation-stackdriver/pom.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2024 The OpenZipkin Authors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.translation.stackdriver;
 

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanTranslator.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.translation.stackdriver;
 

--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanUtil.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/SpanUtil.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.translation.stackdriver;
 

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/AttributesExtractorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/AttributesExtractorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.translation.stackdriver;
 

--- a/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
+++ b/translation-stackdriver/src/test/java/zipkin2/translation/stackdriver/SpanTranslatorTest.java
@@ -1,15 +1,6 @@
 /*
- * Copyright 2016-2024 The OpenZipkin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 package zipkin2.translation.stackdriver;
 


### PR DESCRIPTION
As a small project, we have to conserve resources and not sign up for work that isn't required. I've recently realized many commercial and/or CNCF projects both use SPDX IDs and also don't bother with copyright year. If their legal team is ok with this, surely a volunteer team without access to one, should be, too! Doing so accomplishes the following:

* significantly increases readability of files, particularly small ones
* removes beginning of year maintenance, which cause a lot of FUD last year. IIRC some deployment failed and hours were spent in spite of docs.
* eliminates the need to do a full source check out, just to satisfy the license plugin. This means we can use actions/checkout defaults.

Same as https://github.com/openzipkin/zipkin-reporter-java/pull/257