### PR TITLE
Allow manual runs of the security check

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,7 @@ name: security
 
 # We don't scan documentation-only commits.
 on:  # yamllint disable-line rule:truthy
+  workflow_dispatch: # trigger ad-hoc runs of this action
   push:  # non-tagged pushes to master
     branches:
       - master

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ This repo uses semantic versions. Please keep this in mind when choosing version
 
    Before you start a release, make sure all dependencies are up-to-date, or are documented why not.
    Pay special attention to the [security workflow](.github/workflows/security.yml), which should
-   run clean.
+   run clean. You can manually run the Action to check the release branch is up-to-date.
 
 1. **Alert others you are releasing**
 

--- a/build-bin/configure_lint
+++ b/build-bin/configure_lint
@@ -1,7 +1,8 @@
 #!/bin/sh -ue
 
 # Attempt to install markdown-link-check if absent
-markdown-link-check -V || npm install -g markdown-link-check
+# Pinned until https://github.com/tcort/markdown-link-check/issues/369
+markdown-link-check -V || npm install -g markdown-link-check@3.12.2
 
 # Attempt to install yamllint if absent
 yamllint || pip install --user yamllint


### PR DESCRIPTION
So we can check before releasing that the release branch is up-to-date.