### PR TITLE
Add missing name to child modules for Sonatype Central Portal

### DIFF
--- a/collector-pubsub/pom.xml
+++ b/collector-pubsub/pom.xml
@@ -14,6 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>collector-pubsub</artifactId>
+  <name>Zipkin Collector: Google PubSub</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>

--- a/propagation-stackdriver/pom.xml
+++ b/propagation-stackdriver/pom.xml
@@ -14,6 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>brave-propagation-stackdriver</artifactId>
+  <name>Brave Propagation: Stackdriver</name>
 
   <properties>
     <module.name>brave.propagation.stackdriver</module.name>


### PR DESCRIPTION
flattenMode=ossrh strips inherited names, so each child module needs an explicit name element.

Signed-off-by: Adrian Cole <adrian@tetrate.io>

